### PR TITLE
Fix path for diagnostics to follow file-uri specification on Unix

### DIFF
--- a/language-server/src/server.ts
+++ b/language-server/src/server.ts
@@ -44,7 +44,12 @@ function connect_unreal() {
 
 				let diagnostics: Diagnostic[] = [];
 
-				let filename = "file:///"+msg.readString();
+				// Based on https://en.wikipedia.org/wiki/File_URI_scheme,
+				// file:/// should be on both platforms, but on Linux the path
+				// begins with / while on Windows it is omitted. So we need to
+				// add it here to make sure both platforms are valid.
+				let localpath = msg.readString();
+				let filename = (localpath[0] == '/') ? ("file://" + localpath) : ("file:///" + localpath);
 				//connection.console.log('Diagnostics received: '+filename);
 
 				let msgCount = msg.readInt();


### PR DESCRIPTION
This fixes a bug where the path would get constructed with four leading slashes on Unix, i.e., `file:////home/...`. This URI is parsed to be `//home/...` on `localhost`, which is an invalid path. Fixing this makes the diagnostics work in VSCode when running UE4 under Ubuntu.

The fix simply checks if the path already starts with `/` and prepend one less slash if that is the case. 

I was unable to build the server side of the extension locally, so I tested my changes by editing the generated JS source directly. Since I'm on Ubuntu I've also not tested Windows, but that behaviour should be unchanged.