### PR TITLE
Added keyword completion for Interp property

### DIFF
--- a/language-server/src/completion.ts
+++ b/language-server/src/completion.ts
@@ -643,7 +643,7 @@ function AddKeywordCompletions(completingStr : string, completions : Array<Compl
         "const", "override",
 
         "BlueprintOverride","BlueprintEvent","BlueprintCallable","NotBlueprintCallable","BlueprintPure","NetFunction","DevFunction","Category","Meta","NetMulticast","Client","Server","BlueprintAuthorityOnly","CallInEditor","Unreliable",
-        "EditAnywhere","EditDefaultsOnly","EditInstanceOnly","BlueprintReadWrite","BlueprintReadOnly","NotBlueprintVisible","NotEditable","DefaultComponent","RootComponent","Attach","Transient","NotVisible","EditConst","BlueprintHidden","Replicated","ReplicationCondition",
+        "EditAnywhere","EditDefaultsOnly","EditInstanceOnly","BlueprintReadWrite","BlueprintReadOnly","NotBlueprintVisible","NotEditable","DefaultComponent","RootComponent","Attach","Transient","NotVisible","EditConst","BlueprintHidden","Replicated","ReplicationCondition","Interp",
     ])
     {
         if (CanCompleteTo(completingStr, kw))

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "unreal-angelscript",
     "displayName": "Unreal Angelscript",
     "description": "Language Server and Debug Adapter for use with the UnrealEngine-Angelscript plugin from https://github.com/Hazelight/UnrealEngine-Angelscript",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "publisher": "Hazelight",
     "engines": {
         "vscode": "^1.22.0"


### PR DESCRIPTION
Also bumped patch version (0.6.1 -> 0.6.2)

This should only be merged once Interp support has been added to the Angelscript UE4 branch: https://github.com/Hazelight/UnrealEngine-Angelscript/pull/16