### PR TITLE
Added completion and syntax highlighting for NoClear UPROPERTY keyword

### DIFF
--- a/extension/syntaxes/angelscript.tmLanguage.json
+++ b/extension/syntaxes/angelscript.tmLanguage.json
@@ -8,7 +8,7 @@
 		},
 		{
 			"name": "keyword.macro.uproperty.angelscript",
-			"match": "\\b(EditAnywhere|EditDefaultsOnly|EditInstanceOnly|BlueprintReadWrite|BlueprintReadOnly|NotBlueprintVisible|NotEditable|DefaultComponent|RootComponent|Attach|AttachSocket|Transient|Interp|NotVisible|EditConst|BlueprintHidden|ShowOnActor|Config|Replicated|ReplicationCondition|EditFixedSize)\\b\\s*"
+			"match": "\\b(EditAnywhere|EditDefaultsOnly|EditInstanceOnly|BlueprintReadWrite|BlueprintReadOnly|NotBlueprintVisible|NotEditable|DefaultComponent|RootComponent|Attach|AttachSocket|Transient|Interp|NoClear|NotVisible|EditConst|BlueprintHidden|ShowOnActor|Config|Replicated|ReplicationCondition|EditFixedSize)\\b\\s*"
 		},
 		{
 			"name": "keyword.statement.angelscript",

--- a/language-server/src/completion.ts
+++ b/language-server/src/completion.ts
@@ -643,7 +643,7 @@ function AddKeywordCompletions(completingStr : string, completions : Array<Compl
         "const", "override",
 
         "BlueprintOverride","BlueprintEvent","BlueprintCallable","NotBlueprintCallable","BlueprintPure","NetFunction","DevFunction","Category","Meta","NetMulticast","Client","Server","BlueprintAuthorityOnly","CallInEditor","Unreliable",
-        "EditAnywhere","EditDefaultsOnly","EditInstanceOnly","BlueprintReadWrite","BlueprintReadOnly","NotBlueprintVisible","NotEditable","DefaultComponent","RootComponent","Attach","Transient","NotVisible","EditConst","BlueprintHidden","Replicated","ReplicationCondition","Interp",
+        "EditAnywhere","EditDefaultsOnly","EditInstanceOnly","BlueprintReadWrite","BlueprintReadOnly","NotBlueprintVisible","NotEditable","DefaultComponent","RootComponent","Attach","Transient","NotVisible","EditConst","BlueprintHidden","Replicated","ReplicationCondition","Interp","NoClear",
     ])
     {
         if (CanCompleteTo(completingStr, kw))


### PR DESCRIPTION
Goes along with [this PR on the UnrealEngine-Angelscript repo](https://github.com/Hazelight/UnrealEngine-Angelscript/pull/56).