### PR TITLE
add debug server port as an optional launch parameter

### DIFF
--- a/extension/src/debug.ts
+++ b/extension/src/debug.ts
@@ -21,6 +21,7 @@ const { Subject } = require('await-notify');
 interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 	stopOnEntry?: boolean;
 	trace?: boolean;
+	port?: number;
 }
 
 interface ASBreakpoint
@@ -40,6 +41,8 @@ export class ASDebugSession extends LoggingDebugSession
 	private _variableHandles = new Handles<string>();
 
 	private _configurationDone = new Subject();
+
+	port = 27099;
 
 	/**
 	 * Creates a new debug adapter that is used for one debug session.
@@ -104,7 +107,7 @@ export class ASDebugSession extends LoggingDebugSession
 		response.body.supportsEvaluateForHovers = true;
 		response.body.supportsExceptionInfoRequest = true;
 
-		unreal.connect();
+		unreal.connect(this.port);
 		unreal.sendRequestBreakFilters();
 
 		this.waitingInitializeResponse = response;
@@ -155,7 +158,7 @@ export class ASDebugSession extends LoggingDebugSession
 		// make sure to 'Stop' the buffered logging if 'trace' is not set
 		logger.setup(args.trace ? Logger.LogLevel.Verbose : Logger.LogLevel.Stop, false);
 
-		unreal.connect();
+		unreal.connect(args.port !== undefined ? args.port : this.port);
 		unreal.sendStartDebugging();
 
 		for (let clientPath of this.breakpoints.keys())

--- a/extension/src/unreal-debugclient.ts
+++ b/extension/src/unreal-debugclient.ts
@@ -156,7 +156,7 @@ let unreal : Socket | null = null;
 export let connected = false;
 export let events = new EventEmitter();
 
-export function connect()
+export function connect(port : number)
 {
     if (unreal != null)
     {
@@ -166,7 +166,7 @@ export function connect()
     unreal = new Socket;
     connected = true;
 	//connection.console.log('Connecting to unreal editor...');
-	unreal.connect(27099, "localhost", function()
+	unreal.connect(port, "localhost", function()
 	{
 		//connection.console.log('Connection to unreal editor established.');
 	});

--- a/package.json
+++ b/package.json
@@ -65,6 +65,11 @@
                                 "type": "boolean",
                                 "description": "Enable logging of the Debug Adapter Protocol.",
                                 "default": true
+                            },
+                            "port": {
+                                "type": "number",
+                                "description": "Port to AS debug server",
+                                "default:": 27099
                             }
                         }
                     }


### PR DESCRIPTION
adding port as a launch parameter, useful if you have multiple game process running and want to connect to a specific one (eg server / client)