### PR TITLE
add quick open import command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ The 'Add Import To' (default shortcut: Shift+Alt+I) command from the
 right click menu will try to automatically add an import statement
 to the top of the file to import the type that the command was run on.
 
+### Quick Open Import
+The 'Quick Open Import' (default shortcut: Ctrl+E or Ctrl+P) command from the
+right click menu will try to open the quick open navigation with the import
+statement.
+
 ## Known Issues
 * There is a rare bug causing the language server to crash, breaking
   code completion until visual studio code is reloaded. If you have

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -134,6 +134,23 @@ export function activate(context: ExtensionContext) {
 	});
 
 	context.subscriptions.push(addImportTo);
+
+	let quickOpenImport = vscode.commands.registerCommand('angelscript.quickOpenImport', () => {
+		let activeEditor = vscode.window.activeTextEditor;
+		if (activeEditor != null) {
+			let line_number = activeEditor.selection.active.line;
+			let text_line = activeEditor.document.lineAt(line_number);
+			let text = text_line.text.split(' ');
+			if (text.length != 0 && text[0] === "import") {
+				let path = text[1].slice(0, -1).split('.').join('\\');
+				vscode.commands.executeCommand('workbench.action.quickOpen', path);
+				return;
+			}
+		}
+		vscode.commands.executeCommand('workbench.action.quickOpen', '');
+	});
+	context.subscriptions.push(quickOpenImport);
+
 	console.log("Done activating angelscript extension");
 }
 

--- a/package.json
+++ b/package.json
@@ -108,6 +108,10 @@
             {
                 "command": "angelscript.addImportTo",
                 "title": "Add Import To"
+            },
+            {
+                "command": "angelscript.quickOpenImport",
+                "title": "Quick Open Import"
             }
         ],
         "menus": {
@@ -128,6 +132,11 @@
                     "when": "resourceLangId == angelscript",
                     "command": "angelscript.addImportTo",
                     "group": "navigation"
+                },
+                {
+                    "when": "resourceLangId == angelscript",
+                    "command": "angelscript.quickOpenImport",
+                    "group": "navigation"
                 }
             ]
         },
@@ -140,6 +149,16 @@
             {
                 "command": "angelscript.addImportTo",
                 "key": "alt+shift+i",
+                "when": "editorTextFocus"
+            },
+            {
+                "command": "angelscript.quickOpenImport",
+                "key": "ctrl+e",
+                "when": "editorTextFocus"
+            },
+            {
+                "command": "angelscript.quickOpenImport",
+                "key": "ctrl+p",
                 "when": "editorTextFocus"
             }
         ]


### PR DESCRIPTION
* extends the default quick open command and tries to paste the import of the currently selected line
* default keybind ctrl+e and ctrl+p

It was requested internally to make it easier to open the file of an import. I looked into https://marketplace.visualstudio.com/items?itemName=duXing.quick-go-to-selected-file-path but it only copied the word under the cursor. My take on it as can be seen in the screenshot below is to copy the full line and process it a bit to narrow the search.

![image](https://user-images.githubusercontent.com/7225656/107156807-bcd8fe80-6980-11eb-9d82-45b9e55b4ee7.png)

Note: This is my first time writing VSC extension code, any feedback is more than welcome. Maybe this should be optional in some way etc.