### PR TITLE
call `dbsuper.isUnrealType` instead of testing for function presence

### DIFF
--- a/language-server/src/database.ts
+++ b/language-server/src/database.ts
@@ -922,7 +922,7 @@ export class DBType implements DBSymbol
             let method = dbsuper.getMethod(methodname, false);
             if (method)
             {
-                if (!dbsuper.isUnrealType || method.isBlueprintEvent)
+                if (!dbsuper.isUnrealType() || method.isBlueprintEvent)
                     return true;
             }
             checktype = dbsuper.supertype;


### PR DESCRIPTION
I guess this is meant to be called.