### PR TITLE
Feat: add setting for ignoring glob patterns when searching for AS files

### DIFF
--- a/language-server/src/server.ts
+++ b/language-server/src/server.ts
@@ -42,7 +42,7 @@ import * as inlinevalues from './inline_values';
 import * as colorpicker from './color_picker';
 import * as typehierarchy from './type_hierarchy';
 import * as fs from 'fs';
-let glob = require('glob');
+import * as glob from 'glob';
 
 import { Message, MessageType, readMessages, buildGoTo, buildDisconnect, buildOpenAssets } from './unreal-buffers';
 
@@ -65,6 +65,8 @@ let IsServicingQueues = false;
 let ReceivingTypesTimeout : any = null;
 let SetTypeTimeout = false;
 let UnrealTypesTimedOut = false;
+
+let settings : any = null;
 
 function connect_unreal() {
     if (unreal != null)
@@ -265,7 +267,10 @@ connection.onInitialize((_params): InitializeResult => {
     let GlobsRemaining = Roots.length;
     for (let RootPath of Roots)
     {
-        glob(RootPath + "/**/*.as", null, function (err: any, files: any)
+        let globOptions: glob.IOptions = {
+            ignore: settings?.scriptIgnorePatterns || []
+        };
+        glob(RootPath + "/**/*.as", globOptions, function (err: any, files: any)
         {
             for (let file of files)
             {
@@ -982,7 +987,7 @@ connection.onRequest("angelscript/provideInlineValues", (...params: any[]) : any
  connection.onDidChangeConfiguration(function (change : DidChangeConfigurationParams)
  {
     let settingsObject = change.settings as any;
-    let settings : any = settingsObject.UnrealAngelscript;
+    settings = settingsObject.UnrealAngelscript;
     if (!settings)
         return;
 

--- a/package.json
+++ b/package.json
@@ -124,6 +124,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "When debugging, show an inline value above the function declaration to display the this pointer and Owner of the object."
+                },
+                "UnrealAngelscript.scriptIgnorePatterns": {
+                    "type": "array",
+                    "default": ["Saved", ".plastic"],
+                    "description": "Glob patterns to ignore when searching for script files to parse."
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
                 },
                 "UnrealAngelscript.scriptIgnorePatterns": {
                     "type": "array",
-                    "default": ["Saved", ".plastic"],
+                    "default": ["**/Saved/**", "**/.plastic/**"],
                     "description": "Glob patterns to ignore when searching for script files to parse."
                 }
             }


### PR DESCRIPTION
This PR adds a setting to ignore an array of glob patterns to prevent picking up duplicate files. For example, when I try to "Go to Definition" sometimes the language server will bring me to `Saved/StagedBuilds/.../File.as`, `.plastic/fileCache/.../File.as` (the VSCode extension for PlasticSCM uses this directory to enable file diffs in VSCode), or `builds/.../File.as` (which is where I put packaged builds). I added `Saved` and `.plastic` as defaults as are not specific to me; happy to change as you see fit.