### PR TITLE
Chore: standardize whitespace (4 spaces, trim trailing)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,43 +1,43 @@
 {
-	"version": "0.2.0",
-	"configurations": [
-		{
-			"type": "extensionHost",
-			"request": "launch",
-			"name": "Launch Client",
-			"runtimeExecutable": "${execPath}",
-			"args": [
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "extensionHost",
+            "request": "launch",
+            "name": "Launch Client",
+            "runtimeExecutable": "${execPath}",
+            "args": [
                 "--extensionDevelopmentPath=${workspaceRoot}",
                 //"--enable-proposed-api", "Hazelight.unreal-angelscript"
             ],
-			"outFiles": ["${workspaceRoot}/extension/out/**/*.js"],
-			"preLaunchTask": {
-				"type": "npm",
-				"script": "watch"
-			}
-		},
-		{
-			"type": "node",
-			"request": "attach",
-			"name": "Attach to Server",
-			"port": 6009,
-			"restart": true,
-			"outFiles": ["${workspaceRoot}/language-server/out/**/*.js"]
-		},
-		{
-			"name": "Debug Debug Adapter",
-			"type": "node",
-			"request": "launch",
-			"cwd": "${workspaceRoot}",
-			"program": "${workspaceRoot}/extension/src/debugAdapter.ts",
-			"args": [ "--server=4711" ],
-			"outFiles": [ "${workspaceRoot}/extension/out/**/*.js" ]
-		},
-	],
-	"compounds": [
-		{
-			"name": "Client + Server",
-			"configurations": ["Launch Client", "Attach to Server"]
-		}
-	]
+            "outFiles": ["${workspaceRoot}/extension/out/**/*.js"],
+            "preLaunchTask": {
+                "type": "npm",
+                "script": "watch"
+            }
+        },
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Attach to Server",
+            "port": 6009,
+            "restart": true,
+            "outFiles": ["${workspaceRoot}/language-server/out/**/*.js"]
+        },
+        {
+            "name": "Debug Debug Adapter",
+            "type": "node",
+            "request": "launch",
+            "cwd": "${workspaceRoot}",
+            "program": "${workspaceRoot}/extension/src/debugAdapter.ts",
+            "args": [ "--server=4711" ],
+            "outFiles": [ "${workspaceRoot}/extension/out/**/*.js" ]
+        },
+    ],
+    "compounds": [
+        {
+            "name": "Client + Server",
+            "configurations": ["Launch Client", "Attach to Server"]
+        }
+    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,21 +1,23 @@
 {
-	// set to false to hide directory from the VS Code Document Sidebar
-	"files.exclude": {
-		"client/out/**/*": false,
-		"client/server/**/*": false,
-		"client/node_modules": false,
-		"server/node_modules": false
-	},
-	// set this to false to include "out" folder in search results
-	"search.exclude": {
-		"out": true
-	},
-	"typescript.tsdk": "./node_modules/typescript/lib",
-	"typescript.tsc.autoDetect": "off",
-	"git.enabled": false,
-	"git.ignoreLimitWarning": true,
+    // set to false to hide directory from the VS Code Document Sidebar
+    "files.exclude": {
+        "client/out/**/*": false,
+        "client/server/**/*": false,
+        "client/node_modules": false,
+        "server/node_modules": false
+    },
+    // set this to false to include "out" folder in search results
+    "search.exclude": {
+        "out": true
+    },
+    "typescript.tsdk": "./node_modules/typescript/lib",
+    "typescript.tsc.autoDetect": "off",
+    "git.enabled": false,
+    "git.ignoreLimitWarning": true,
 
-	"editor.insertSpaces": true,
-	"editor.tabSize": 4,
-	"editor.detectIndentation": false,
+    "editor.insertSpaces": true,
+    "editor.tabSize": 4,
+    "editor.detectIndentation": false,
+
+    "files.trimTrailingWhitespace": true
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,33 +1,33 @@
 {
-	"version": "2.0.0",
-	"tasks": [
-		{
-			"type": "npm",
-			"script": "compile",
-			"group": "build",
-			"presentation": {
-				"panel": "dedicated",
-				"reveal": "never"
-			},
-			"problemMatcher": [
-				"$tsc"
-			]
-		},
-		{
-			"type": "npm",
-			"script": "watch",
-			"isBackground": true,
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			},
-			"presentation": {
-				"panel": "dedicated",
-				"reveal": "never"
-			},
-			"problemMatcher": [
-				"$tsc-watch"
-			]
-		}
-	]
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "compile",
+            "group": "build",
+            "presentation": {
+                "panel": "dedicated",
+                "reveal": "never"
+            },
+            "problemMatcher": [
+                "$tsc"
+            ]
+        },
+        {
+            "type": "npm",
+            "script": "watch",
+            "isBackground": true,
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "panel": "dedicated",
+                "reveal": "never"
+            },
+            "problemMatcher": [
+                "$tsc-watch"
+            ]
+        }
+    ]
 }

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,980 +1,980 @@
 {
-	"name": "unreal-angelscript",
-	"version": "0.0.1",
-	"lockfileVersion": 2,
-	"requires": true,
-	"packages": {
-		"": {
-			"name": "unreal-angelscript",
-			"version": "0.0.1",
-			"dependencies": {
-				"await-notify": "^1.0.1",
-				"vscode-debugadapter": "^1.48.0",
-				"vscode-languageclient": "^8.0.1"
-			},
-			"devDependencies": {
-				"@types/vscode": "^1.65.0",
-				"typescript": "^4.5.5",
-				"vscode-test": "^1.3.0"
-			},
-			"engines": {
-				"vscode": "^1.65.0"
-			}
-		},
-		"node_modules/@tootallnate/once": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/@types/vscode": {
-			"version": "1.68.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.68.0.tgz",
-			"integrity": "sha512-duBwEK5ta/eBBMJMQ7ECMEsMvlE3XJdRGh3xoS1uOO4jl2Z4LPBl5vx8WvBP10ERAgDRmIt/FaSD4RHyBGbChw==",
-			"dev": true
-		},
-		"node_modules/agent-base": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-			"dev": true,
-			"dependencies": {
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6.0.0"
-			}
-		},
-		"node_modules/await-notify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/await-notify/-/await-notify-1.0.1.tgz",
-			"integrity": "sha512-eT6XN2ycPKvuiffzUNmU0dnGmmLw+TexMW7UKOyf5utdVrWx14PR2acRIfy6ZfFWRAv8twt1X74VUgd9RnDmfQ=="
-		},
-		"node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-		},
-		"node_modules/big-integer": {
-			"version": "1.6.51",
-			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-			"integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.6"
-			}
-		},
-		"node_modules/binary": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-			"integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-			"dev": true,
-			"dependencies": {
-				"buffers": "~0.1.1",
-				"chainsaw": "~0.1.0"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/bluebird": {
-			"version": "3.4.7",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-			"integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
-			"dev": true
-		},
-		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/buffer-indexof-polyfill": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-			"integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"node_modules/buffers": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-			"integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.2.0"
-			}
-		},
-		"node_modules/chainsaw": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-			"integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-			"dev": true,
-			"dependencies": {
-				"traverse": ">=0.3.0 <0.4"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-		},
-		"node_modules/core-util-is": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-			"dev": true
-		},
-		"node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/duplexer2": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-			"integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-			"dev": true,
-			"dependencies": {
-				"readable-stream": "^2.0.2"
-			}
-		},
-		"node_modules/fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-			"dev": true
-		},
-		"node_modules/fstream": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-			"dev": true,
-			"dependencies": {
-				"graceful-fs": "^4.1.2",
-				"inherits": "~2.0.0",
-				"mkdirp": ">=0.5 0",
-				"rimraf": "2"
-			},
-			"engines": {
-				"node": ">=0.6"
-			}
-		},
-		"node_modules/fstream/node_modules/mkdirp": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-			"dev": true,
-			"dependencies": {
-				"minimist": "^1.2.6"
-			},
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			}
-		},
-		"node_modules/fstream/node_modules/rimraf": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-			"dev": true,
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			}
-		},
-		"node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"dev": true,
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/graceful-fs": {
-			"version": "4.2.10",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-			"dev": true
-		},
-		"node_modules/http-proxy-agent": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-			"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-			"dev": true,
-			"dependencies": {
-				"@tootallnate/once": "1",
-				"agent-base": "6",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/https-proxy-agent": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-			"dev": true,
-			"dependencies": {
-				"agent-base": "6",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-			"dev": true,
-			"dependencies": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
-		"node_modules/inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
-		},
-		"node_modules/isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true
-		},
-		"node_modules/listenercount": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-			"integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
-			"dev": true
-		},
-		"node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/minimist": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-			"dev": true
-		},
-		"node_modules/mkdirp": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
-		},
-		"node_modules/once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-			"dev": true,
-			"dependencies": {
-				"wrappy": "1"
-			}
-		},
-		"node_modules/path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/process-nextick-args": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true
-		},
-		"node_modules/readable-stream": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"dev": true,
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"dev": true,
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"node_modules/semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-			"dev": true
-		},
-		"node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
-		"node_modules/traverse": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-			"integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/typescript": {
-			"version": "4.7.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
-			"integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
-			"dev": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=4.2.0"
-			}
-		},
-		"node_modules/unzipper": {
-			"version": "0.10.11",
-			"resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-			"integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
-			"dev": true,
-			"dependencies": {
-				"big-integer": "^1.6.17",
-				"binary": "~0.3.0",
-				"bluebird": "~3.4.1",
-				"buffer-indexof-polyfill": "~1.0.0",
-				"duplexer2": "~0.1.4",
-				"fstream": "^1.0.12",
-				"graceful-fs": "^4.2.2",
-				"listenercount": "~1.0.1",
-				"readable-stream": "~2.3.6",
-				"setimmediate": "~1.0.4"
-			}
-		},
-		"node_modules/util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true
-		},
-		"node_modules/vscode-debugadapter": {
-			"version": "1.51.0",
-			"resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.51.0.tgz",
-			"integrity": "sha512-mObaXD5/FH/z6aL2GDuyCLbnwLsYRCAJWgFid01vKW9Y5Si8OvINK+Tn+Yl/lRUbetjNuZW3j1euMEz6z8Yzqg==",
-			"deprecated": "This package has been renamed to @vscode/debugadapter, please update to the new name",
-			"dependencies": {
-				"mkdirp": "^1.0.4",
-				"vscode-debugprotocol": "1.51.0"
-			}
-		},
-		"node_modules/vscode-debugprotocol": {
-			"version": "1.51.0",
-			"resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.51.0.tgz",
-			"integrity": "sha512-dzKWTMMyebIMPF1VYMuuQj7gGFq7guR8AFya0mKacu+ayptJfaRuM0mdHCqiOth4FnRP8mPhEroFPx6Ift8wHA==",
-			"deprecated": "This package has been renamed to @vscode/debugprotocol, please update to the new name"
-		},
-		"node_modules/vscode-jsonrpc": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz",
-			"integrity": "sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ==",
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/vscode-languageclient": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.1.tgz",
-			"integrity": "sha512-9XoE+HJfaWvu7Y75H3VmLo5WLCtsbxEgEhrLPqwt7eyoR49lUIyyrjb98Yfa50JCMqF2cePJAEVI6oe2o1sIhw==",
-			"dependencies": {
-				"minimatch": "^3.0.4",
-				"semver": "^7.3.5",
-				"vscode-languageserver-protocol": "3.17.1"
-			},
-			"engines": {
-				"vscode": "^1.67.0"
-			}
-		},
-		"node_modules/vscode-languageserver-protocol": {
-			"version": "3.17.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz",
-			"integrity": "sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==",
-			"dependencies": {
-				"vscode-jsonrpc": "8.0.1",
-				"vscode-languageserver-types": "3.17.1"
-			}
-		},
-		"node_modules/vscode-languageserver-types": {
-			"version": "3.17.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz",
-			"integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ=="
-		},
-		"node_modules/vscode-test": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-			"integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
-			"deprecated": "This package has been renamed to @vscode/test-electron, please update to the new name",
-			"dev": true,
-			"dependencies": {
-				"http-proxy-agent": "^4.0.1",
-				"https-proxy-agent": "^5.0.0",
-				"rimraf": "^3.0.2",
-				"unzipper": "^0.10.11"
-			},
-			"engines": {
-				"node": ">=8.9.3"
-			}
-		},
-		"node_modules/wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"dev": true
-		},
-		"node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-		}
-	},
-	"dependencies": {
-		"@tootallnate/once": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-			"dev": true
-		},
-		"@types/vscode": {
-			"version": "1.68.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.68.0.tgz",
-			"integrity": "sha512-duBwEK5ta/eBBMJMQ7ECMEsMvlE3XJdRGh3xoS1uOO4jl2Z4LPBl5vx8WvBP10ERAgDRmIt/FaSD4RHyBGbChw==",
-			"dev": true
-		},
-		"agent-base": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-			"dev": true,
-			"requires": {
-				"debug": "4"
-			}
-		},
-		"await-notify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/await-notify/-/await-notify-1.0.1.tgz",
-			"integrity": "sha512-eT6XN2ycPKvuiffzUNmU0dnGmmLw+TexMW7UKOyf5utdVrWx14PR2acRIfy6ZfFWRAv8twt1X74VUgd9RnDmfQ=="
-		},
-		"balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-		},
-		"big-integer": {
-			"version": "1.6.51",
-			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-			"integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-			"dev": true
-		},
-		"binary": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-			"integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-			"dev": true,
-			"requires": {
-				"buffers": "~0.1.1",
-				"chainsaw": "~0.1.0"
-			}
-		},
-		"bluebird": {
-			"version": "3.4.7",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-			"integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
-			"dev": true
-		},
-		"brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"requires": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"buffer-indexof-polyfill": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-			"integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-			"dev": true
-		},
-		"buffers": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-			"integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-			"dev": true
-		},
-		"chainsaw": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-			"integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-			"dev": true,
-			"requires": {
-				"traverse": ">=0.3.0 <0.4"
-			}
-		},
-		"concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-		},
-		"core-util-is": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-			"dev": true
-		},
-		"debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"requires": {
-				"ms": "2.1.2"
-			}
-		},
-		"duplexer2": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-			"integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-			"dev": true,
-			"requires": {
-				"readable-stream": "^2.0.2"
-			}
-		},
-		"fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-			"dev": true
-		},
-		"fstream": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"inherits": "~2.0.0",
-				"mkdirp": ">=0.5 0",
-				"rimraf": "2"
-			},
-			"dependencies": {
-				"mkdirp": {
-					"version": "0.5.6",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-					"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.6"
-					}
-				},
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
-			}
-		},
-		"glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"dev": true,
-			"requires": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			}
-		},
-		"graceful-fs": {
-			"version": "4.2.10",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-			"dev": true
-		},
-		"http-proxy-agent": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-			"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-			"dev": true,
-			"requires": {
-				"@tootallnate/once": "1",
-				"agent-base": "6",
-				"debug": "4"
-			}
-		},
-		"https-proxy-agent": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-			"dev": true,
-			"requires": {
-				"agent-base": "6",
-				"debug": "4"
-			}
-		},
-		"inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-			"dev": true,
-			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
-		"inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
-		},
-		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true
-		},
-		"listenercount": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-			"integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
-			"dev": true
-		},
-		"lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"requires": {
-				"yallist": "^4.0.0"
-			}
-		},
-		"minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"requires": {
-				"brace-expansion": "^1.1.7"
-			}
-		},
-		"minimist": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-			"dev": true
-		},
-		"mkdirp": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-		},
-		"ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
-		},
-		"once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-			"dev": true,
-			"requires": {
-				"wrappy": "1"
-			}
-		},
-		"path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-			"dev": true
-		},
-		"process-nextick-args": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true
-		},
-		"readable-stream": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"dev": true,
-			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"dev": true,
-			"requires": {
-				"glob": "^7.1.3"
-			}
-		},
-		"safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-			"requires": {
-				"lru-cache": "^6.0.0"
-			}
-		},
-		"setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-			"dev": true
-		},
-		"string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
-		"traverse": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-			"integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-			"dev": true
-		},
-		"typescript": {
-			"version": "4.7.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
-			"integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
-			"dev": true
-		},
-		"unzipper": {
-			"version": "0.10.11",
-			"resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-			"integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
-			"dev": true,
-			"requires": {
-				"big-integer": "^1.6.17",
-				"binary": "~0.3.0",
-				"bluebird": "~3.4.1",
-				"buffer-indexof-polyfill": "~1.0.0",
-				"duplexer2": "~0.1.4",
-				"fstream": "^1.0.12",
-				"graceful-fs": "^4.2.2",
-				"listenercount": "~1.0.1",
-				"readable-stream": "~2.3.6",
-				"setimmediate": "~1.0.4"
-			}
-		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true
-		},
-		"vscode-debugadapter": {
-			"version": "1.51.0",
-			"resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.51.0.tgz",
-			"integrity": "sha512-mObaXD5/FH/z6aL2GDuyCLbnwLsYRCAJWgFid01vKW9Y5Si8OvINK+Tn+Yl/lRUbetjNuZW3j1euMEz6z8Yzqg==",
-			"requires": {
-				"mkdirp": "^1.0.4",
-				"vscode-debugprotocol": "1.51.0"
-			}
-		},
-		"vscode-debugprotocol": {
-			"version": "1.51.0",
-			"resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.51.0.tgz",
-			"integrity": "sha512-dzKWTMMyebIMPF1VYMuuQj7gGFq7guR8AFya0mKacu+ayptJfaRuM0mdHCqiOth4FnRP8mPhEroFPx6Ift8wHA=="
-		},
-		"vscode-jsonrpc": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz",
-			"integrity": "sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ=="
-		},
-		"vscode-languageclient": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.1.tgz",
-			"integrity": "sha512-9XoE+HJfaWvu7Y75H3VmLo5WLCtsbxEgEhrLPqwt7eyoR49lUIyyrjb98Yfa50JCMqF2cePJAEVI6oe2o1sIhw==",
-			"requires": {
-				"minimatch": "^3.0.4",
-				"semver": "^7.3.5",
-				"vscode-languageserver-protocol": "3.17.1"
-			}
-		},
-		"vscode-languageserver-protocol": {
-			"version": "3.17.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz",
-			"integrity": "sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==",
-			"requires": {
-				"vscode-jsonrpc": "8.0.1",
-				"vscode-languageserver-types": "3.17.1"
-			}
-		},
-		"vscode-languageserver-types": {
-			"version": "3.17.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz",
-			"integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ=="
-		},
-		"vscode-test": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-			"integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
-			"dev": true,
-			"requires": {
-				"http-proxy-agent": "^4.0.1",
-				"https-proxy-agent": "^5.0.0",
-				"rimraf": "^3.0.2",
-				"unzipper": "^0.10.11"
-			}
-		},
-		"wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"dev": true
-		},
-		"yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-		}
-	}
+    "name": "unreal-angelscript",
+    "version": "0.0.1",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "unreal-angelscript",
+            "version": "0.0.1",
+            "dependencies": {
+                "await-notify": "^1.0.1",
+                "vscode-debugadapter": "^1.48.0",
+                "vscode-languageclient": "^8.0.1"
+            },
+            "devDependencies": {
+                "@types/vscode": "^1.65.0",
+                "typescript": "^4.5.5",
+                "vscode-test": "^1.3.0"
+            },
+            "engines": {
+                "vscode": "^1.65.0"
+            }
+        },
+        "node_modules/@tootallnate/once": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/@types/vscode": {
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.68.0.tgz",
+            "integrity": "sha512-duBwEK5ta/eBBMJMQ7ECMEsMvlE3XJdRGh3xoS1uOO4jl2Z4LPBl5vx8WvBP10ERAgDRmIt/FaSD4RHyBGbChw==",
+            "dev": true
+        },
+        "node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/await-notify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/await-notify/-/await-notify-1.0.1.tgz",
+            "integrity": "sha512-eT6XN2ycPKvuiffzUNmU0dnGmmLw+TexMW7UKOyf5utdVrWx14PR2acRIfy6ZfFWRAv8twt1X74VUgd9RnDmfQ=="
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+        },
+        "node_modules/big-integer": {
+            "version": "1.6.51",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/binary": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+            "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+            "dev": true,
+            "dependencies": {
+                "buffers": "~0.1.1",
+                "chainsaw": "~0.1.0"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/bluebird": {
+            "version": "3.4.7",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+            "dev": true
+        },
+        "node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/buffer-indexof-polyfill": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/buffers": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+            "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.2.0"
+            }
+        },
+        "node_modules/chainsaw": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+            "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+            "dev": true,
+            "dependencies": {
+                "traverse": ">=0.3.0 <0.4"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+        },
+        "node_modules/core-util-is": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+            "dev": true
+        },
+        "node_modules/debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/duplexer2": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+            "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+            "dev": true,
+            "dependencies": {
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+            "dev": true
+        },
+        "node_modules/fstream": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+            "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
+            },
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/fstream/node_modules/mkdirp": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+            "dev": true,
+            "dependencies": {
+                "minimist": "^1.2.6"
+            },
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            }
+        },
+        "node_modules/fstream/node_modules/rimraf": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+            "dev": true,
+            "dependencies": {
+                "glob": "^7.1.3"
+            },
+            "bin": {
+                "rimraf": "bin.js"
+            }
+        },
+        "node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.10",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "dev": true
+        },
+        "node_modules/http-proxy-agent": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+            "dev": true,
+            "dependencies": {
+                "@tootallnate/once": "1",
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+            "dev": true,
+            "dependencies": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
+        },
+        "node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "dev": true
+        },
+        "node_modules/listenercount": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+            "dev": true
+        },
+        "node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/minimist": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+            "dev": true
+        },
+        "node_modules/mkdirp": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dev": true,
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true
+        },
+        "node_modules/readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dev": true,
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/rimraf": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "dev": true,
+            "dependencies": {
+                "glob": "^7.1.3"
+            },
+            "bin": {
+                "rimraf": "bin.js"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
+        },
+        "node_modules/semver": {
+            "version": "7.3.7",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/setimmediate": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+            "dev": true
+        },
+        "node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/traverse": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+            "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "4.7.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
+            "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
+        "node_modules/unzipper": {
+            "version": "0.10.11",
+            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
+            "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+            "dev": true,
+            "dependencies": {
+                "big-integer": "^1.6.17",
+                "binary": "~0.3.0",
+                "bluebird": "~3.4.1",
+                "buffer-indexof-polyfill": "~1.0.0",
+                "duplexer2": "~0.1.4",
+                "fstream": "^1.0.12",
+                "graceful-fs": "^4.2.2",
+                "listenercount": "~1.0.1",
+                "readable-stream": "~2.3.6",
+                "setimmediate": "~1.0.4"
+            }
+        },
+        "node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+            "dev": true
+        },
+        "node_modules/vscode-debugadapter": {
+            "version": "1.51.0",
+            "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.51.0.tgz",
+            "integrity": "sha512-mObaXD5/FH/z6aL2GDuyCLbnwLsYRCAJWgFid01vKW9Y5Si8OvINK+Tn+Yl/lRUbetjNuZW3j1euMEz6z8Yzqg==",
+            "deprecated": "This package has been renamed to @vscode/debugadapter, please update to the new name",
+            "dependencies": {
+                "mkdirp": "^1.0.4",
+                "vscode-debugprotocol": "1.51.0"
+            }
+        },
+        "node_modules/vscode-debugprotocol": {
+            "version": "1.51.0",
+            "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.51.0.tgz",
+            "integrity": "sha512-dzKWTMMyebIMPF1VYMuuQj7gGFq7guR8AFya0mKacu+ayptJfaRuM0mdHCqiOth4FnRP8mPhEroFPx6Ift8wHA==",
+            "deprecated": "This package has been renamed to @vscode/debugprotocol, please update to the new name"
+        },
+        "node_modules/vscode-jsonrpc": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz",
+            "integrity": "sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ==",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/vscode-languageclient": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.1.tgz",
+            "integrity": "sha512-9XoE+HJfaWvu7Y75H3VmLo5WLCtsbxEgEhrLPqwt7eyoR49lUIyyrjb98Yfa50JCMqF2cePJAEVI6oe2o1sIhw==",
+            "dependencies": {
+                "minimatch": "^3.0.4",
+                "semver": "^7.3.5",
+                "vscode-languageserver-protocol": "3.17.1"
+            },
+            "engines": {
+                "vscode": "^1.67.0"
+            }
+        },
+        "node_modules/vscode-languageserver-protocol": {
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz",
+            "integrity": "sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==",
+            "dependencies": {
+                "vscode-jsonrpc": "8.0.1",
+                "vscode-languageserver-types": "3.17.1"
+            }
+        },
+        "node_modules/vscode-languageserver-types": {
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz",
+            "integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ=="
+        },
+        "node_modules/vscode-test": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
+            "integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
+            "deprecated": "This package has been renamed to @vscode/test-electron, please update to the new name",
+            "dev": true,
+            "dependencies": {
+                "http-proxy-agent": "^4.0.1",
+                "https-proxy-agent": "^5.0.0",
+                "rimraf": "^3.0.2",
+                "unzipper": "^0.10.11"
+            },
+            "engines": {
+                "node": ">=8.9.3"
+            }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true
+        },
+        "node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+    },
+    "dependencies": {
+        "@tootallnate/once": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+            "dev": true
+        },
+        "@types/vscode": {
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.68.0.tgz",
+            "integrity": "sha512-duBwEK5ta/eBBMJMQ7ECMEsMvlE3XJdRGh3xoS1uOO4jl2Z4LPBl5vx8WvBP10ERAgDRmIt/FaSD4RHyBGbChw==",
+            "dev": true
+        },
+        "agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
+            "requires": {
+                "debug": "4"
+            }
+        },
+        "await-notify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/await-notify/-/await-notify-1.0.1.tgz",
+            "integrity": "sha512-eT6XN2ycPKvuiffzUNmU0dnGmmLw+TexMW7UKOyf5utdVrWx14PR2acRIfy6ZfFWRAv8twt1X74VUgd9RnDmfQ=="
+        },
+        "balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+        },
+        "big-integer": {
+            "version": "1.6.51",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+            "dev": true
+        },
+        "binary": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+            "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+            "dev": true,
+            "requires": {
+                "buffers": "~0.1.1",
+                "chainsaw": "~0.1.0"
+            }
+        },
+        "bluebird": {
+            "version": "3.4.7",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+            "dev": true
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "buffer-indexof-polyfill": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+            "dev": true
+        },
+        "buffers": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+            "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+            "dev": true
+        },
+        "chainsaw": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+            "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+            "dev": true,
+            "requires": {
+                "traverse": ">=0.3.0 <0.4"
+            }
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+        },
+        "core-util-is": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+            "dev": true
+        },
+        "debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dev": true,
+            "requires": {
+                "ms": "2.1.2"
+            }
+        },
+        "duplexer2": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+            "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+            "dev": true
+        },
+        "fstream": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+            "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
+            },
+            "dependencies": {
+                "mkdirp": {
+                    "version": "0.5.6",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+                    "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.6"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.7.1",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+                    "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                }
+            }
+        },
+        "glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "graceful-fs": {
+            "version": "4.2.10",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "dev": true
+        },
+        "http-proxy-agent": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+            "dev": true,
+            "requires": {
+                "@tootallnate/once": "1",
+                "agent-base": "6",
+                "debug": "4"
+            }
+        },
+        "https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
+            "requires": {
+                "agent-base": "6",
+                "debug": "4"
+            }
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "dev": true
+        },
+        "listenercount": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+            "dev": true
+        },
+        "lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "requires": {
+                "yallist": "^4.0.0"
+            }
+        },
+        "minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+        },
+        "ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dev": true,
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+            "dev": true
+        },
+        "process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true
+        },
+        "readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dev": true,
+            "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "rimraf": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
+        },
+        "semver": {
+            "version": "7.3.7",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+            "requires": {
+                "lru-cache": "^6.0.0"
+            }
+        },
+        "setimmediate": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+            "dev": true
+        },
+        "string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "traverse": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+            "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+            "dev": true
+        },
+        "typescript": {
+            "version": "4.7.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
+            "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
+            "dev": true
+        },
+        "unzipper": {
+            "version": "0.10.11",
+            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
+            "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+            "dev": true,
+            "requires": {
+                "big-integer": "^1.6.17",
+                "binary": "~0.3.0",
+                "bluebird": "~3.4.1",
+                "buffer-indexof-polyfill": "~1.0.0",
+                "duplexer2": "~0.1.4",
+                "fstream": "^1.0.12",
+                "graceful-fs": "^4.2.2",
+                "listenercount": "~1.0.1",
+                "readable-stream": "~2.3.6",
+                "setimmediate": "~1.0.4"
+            }
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+            "dev": true
+        },
+        "vscode-debugadapter": {
+            "version": "1.51.0",
+            "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.51.0.tgz",
+            "integrity": "sha512-mObaXD5/FH/z6aL2GDuyCLbnwLsYRCAJWgFid01vKW9Y5Si8OvINK+Tn+Yl/lRUbetjNuZW3j1euMEz6z8Yzqg==",
+            "requires": {
+                "mkdirp": "^1.0.4",
+                "vscode-debugprotocol": "1.51.0"
+            }
+        },
+        "vscode-debugprotocol": {
+            "version": "1.51.0",
+            "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.51.0.tgz",
+            "integrity": "sha512-dzKWTMMyebIMPF1VYMuuQj7gGFq7guR8AFya0mKacu+ayptJfaRuM0mdHCqiOth4FnRP8mPhEroFPx6Ift8wHA=="
+        },
+        "vscode-jsonrpc": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz",
+            "integrity": "sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ=="
+        },
+        "vscode-languageclient": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.1.tgz",
+            "integrity": "sha512-9XoE+HJfaWvu7Y75H3VmLo5WLCtsbxEgEhrLPqwt7eyoR49lUIyyrjb98Yfa50JCMqF2cePJAEVI6oe2o1sIhw==",
+            "requires": {
+                "minimatch": "^3.0.4",
+                "semver": "^7.3.5",
+                "vscode-languageserver-protocol": "3.17.1"
+            }
+        },
+        "vscode-languageserver-protocol": {
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz",
+            "integrity": "sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==",
+            "requires": {
+                "vscode-jsonrpc": "8.0.1",
+                "vscode-languageserver-types": "3.17.1"
+            }
+        },
+        "vscode-languageserver-types": {
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz",
+            "integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ=="
+        },
+        "vscode-test": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
+            "integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
+            "dev": true,
+            "requires": {
+                "http-proxy-agent": "^4.0.1",
+                "https-proxy-agent": "^5.0.0",
+                "rimraf": "^3.0.2",
+                "unzipper": "^0.10.11"
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true
+        },
+        "yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+    }
 }

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,20 +1,20 @@
 {
-	"name": "unreal-angelscript",
-	"displayName": "Unreal Angelscript",
-	"description": "Implements support for unreal-bound angelscript files.",
-	"version": "0.0.1",
-	"publisher": "Hazelight",
-	"engines": {
-		"vscode": "^1.65.0"
-	},
-	"dependencies": {
-		"await-notify": "^1.0.1",
-		"vscode-debugadapter": "^1.48.0",
-		"vscode-languageclient": "^8.0.1"
-	},
-	"devDependencies": {
-		"@types/vscode": "^1.65.0",
-		"typescript": "^4.5.5",
-		"vscode-test": "^1.3.0"
-	}
+    "name": "unreal-angelscript",
+    "displayName": "Unreal Angelscript",
+    "description": "Implements support for unreal-bound angelscript files.",
+    "version": "0.0.1",
+    "publisher": "Hazelight",
+    "engines": {
+        "vscode": "^1.65.0"
+    },
+    "dependencies": {
+        "await-notify": "^1.0.1",
+        "vscode-debugadapter": "^1.48.0",
+        "vscode-languageclient": "^8.0.1"
+    },
+    "devDependencies": {
+        "@types/vscode": "^1.65.0",
+        "typescript": "^4.5.5",
+        "vscode-test": "^1.3.0"
+    }
 }

--- a/extension/src/debug.ts
+++ b/extension/src/debug.ts
@@ -4,11 +4,11 @@
  *--------------------------------------------------------*/
 
 import {
-	Logger, logger,
-	LoggingDebugSession,
-	InitializedEvent, TerminatedEvent, StoppedEvent, BreakpointEvent, OutputEvent,
-	ContinuedEvent,
-	Thread, StackFrame, Scope, Source, Handles, Breakpoint
+    Logger, logger,
+    LoggingDebugSession,
+    InitializedEvent, TerminatedEvent, StoppedEvent, BreakpointEvent, OutputEvent,
+    ContinuedEvent,
+    Thread, StackFrame, Scope, Source, Handles, Breakpoint
 } from 'vscode-debugadapter';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { basename } from 'path';
@@ -19,600 +19,600 @@ const { Subject } = require('await-notify');
 
 
 interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
-	trace?: boolean;
-	port?: number;
+    trace?: boolean;
+    port?: number;
 }
 
 interface ASBreakpoint
 {
-	id : number;
-	line : number;
+    id : number;
+    line : number;
 }
 
 export class ASDebugSession extends LoggingDebugSession
 {
-	// we don't support multiple threads, so we can use a hardcoded ID for the default thread
-	private static THREAD_ID = 1;
-
-	private breakpoints = new Map<string, ASBreakpoint[]>();
-	private nextBreakpointId = 1;
-
-	private _variableHandles = new Handles<string>();
-
-	private _configurationDone = new Subject();
-
-	port = 27099;
-
-	/**
-	 * Creates a new debug adapter that is used for one debug session.
-	 * We configure the default implementation of a debug adapter here.
-	 */
-	public constructor()
-	{
-		super("angelscript-debug");
-
-		this.setDebuggerLinesStartAt1(true);
-		this.setDebuggerColumnsStartAt1(true);
-
-		unreal.events.removeAllListeners();
-		unreal.events.on("CallStack", (msg : unreal.Message) => {
-			this.receiveCallStack(msg);
-		});
-
-		unreal.events.on("Stopped", (msg : unreal.Message) => {
-			this.receiveStopped(msg);
-		});
-
-		unreal.events.on("Continued", (msg : unreal.Message) => {
-			this.receiveContinued();
-		});
-
-		unreal.events.on("Variables", (msg : unreal.Message) => {
-			this.receiveVariables(msg);
-		});
-
-		unreal.events.on("Evaluate", (msg : unreal.Message) => {
-			this.receiveEvaluate(msg);
-		});
-
-		unreal.events.on("BreakFilters", (msg : unreal.Message) => {
-			this.receiveBreakFilters(msg);
-		});
-
-		unreal.events.on("Closed", () => {
-			this.receiveClosed();
-		});
-
-		unreal.events.on("SetBreakpoint", (msg : unreal.Message) => {
-			this.receiveBreakpoint(msg);
-		});
-	}
-
-	/**
-	 * The 'initialize' request is the first request called by the frontend
-	 * to interrogate the features the debug adapter provides.
-	 */
-
-	waitingInitializeResponse : DebugProtocol.InitializeResponse;
-	protected initializeRequest(response: DebugProtocol.InitializeResponse, args: DebugProtocol.InitializeRequestArguments) : void
-	{
-		// build and return the capabilities of this debug adapter:
-		response.body = response.body || {};
-
-		// the adapter implements the configurationDoneRequest.
-		response.body.supportsConfigurationDoneRequest = true;
-
-		// make VS Code to use 'evaluate' when hovering over source
-		response.body.supportsEvaluateForHovers = true;
-		response.body.supportsExceptionInfoRequest = true;
-
-		unreal.connect(this.port);
-		unreal.sendRequestBreakFilters();
-
-		this.waitingInitializeResponse = response;
-	}
-
-	receiveBreakFilters(msg : unreal.Message) : void
-	{
-		this.waitingInitializeResponse.body.exceptionBreakpointFilters = [];
-		let count = msg.readInt();
-		for (let i = 0; i < count; ++i)
-		{
-			let filter = msg.readString();
-			let filterTitle = msg.readString();
-
-			this.waitingInitializeResponse.body.exceptionBreakpointFilters.push(
-				<DebugProtocol.ExceptionBreakpointsFilter> {
-					filter: filter,
-					label: filterTitle,
-					default: true,
-				}, 
-			);
-		}
-
-		unreal.disconnect();
-
-		this.sendResponse(this.waitingInitializeResponse);
-
-		// since this debug adapter can accept configuration requests like 'setASBreakpoint' at any time,
-		// we request them early by sending an 'initializeRequest' to the frontend.
-		// The frontend will end the configuration sequence by calling 'configurationDone' request.
-		this.sendEvent(new InitializedEvent());
-	}
-
-	/**
-	 * Called at the end of the configuration sequence.
-	 * Indicates that all breakpoints etc. have been sent to the DA and that the 'launch' can start.
-	 */
-	protected configurationDoneRequest(response: DebugProtocol.ConfigurationDoneResponse, args: DebugProtocol.ConfigurationDoneArguments) : void
-	{
-		super.configurationDoneRequest(response, args);
-
-		// notify the launchRequest that configuration has finished
-		this._configurationDone.notify();
-	}
-
-	protected async launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments)
-	{
-		// make sure to 'Stop' the buffered logging if 'trace' is not set
-		logger.setup(args.trace ? Logger.LogLevel.Verbose : Logger.LogLevel.Stop, false);
-
-		unreal.connect(args.port !== undefined ? args.port : this.port);
-		unreal.sendStartDebugging();
-
-		for (let clientPath of this.breakpoints.keys())
-		{
-			let breakpointList = this.getBreakpointList(clientPath);
-			if (breakpointList.length != 0)
-			{
-				const debugPath = this.convertClientPathToDebugger(clientPath);
-				unreal.clearBreakpoints(debugPath);
-
-				for(let breakpoint of breakpointList)
-				{
-					unreal.setBreakpoint(breakpoint.id, debugPath, breakpoint.line);
-				}
-			}
-		}
-
-		// wait until configuration has finished (and configurationDoneRequest has been called)
-		await this._configurationDone.wait(1000);
-
-		this.sendResponse(response);
-	}
-
-	protected disconnectRequest(response: DebugProtocol.DisconnectResponse, args: DebugProtocol.DisconnectArguments): void
-	{
-		unreal.sendStopDebugging();
-		unreal.disconnect();
-
-		this.sendResponse(response);
-	}
-
-	protected getBreakpointList(path : string) : Array<ASBreakpoint>
-	{
-		let breakpointList = this.breakpoints.get(path);
-		if(!breakpointList)
-		{
-			breakpointList = new Array<ASBreakpoint>();
-			this.breakpoints.set(path, breakpointList);
-		}
-		return breakpointList;
-	}
-
-	protected setBreakPointsRequest(response: DebugProtocol.SetBreakpointsResponse, args: DebugProtocol.SetBreakpointsArguments) : void
-	{
-		const clientLines = args.lines || [];
-		const clientPath = <string>args.source.path;
-		const debugPath = this.convertClientPathToDebugger(clientPath);
-
-		let clientBreakpoints = new Array<DebugProtocol.Breakpoint>();
-		let oldBreakpointList = this.getBreakpointList(clientPath);
-		let breakpointList = new Array<ASBreakpoint>();
-
-		if(unreal.connected)
-			unreal.clearBreakpoints(debugPath);
-
-		for (let line of clientLines)
-		{
-			let id = -1; 
-			for (let oldBP of oldBreakpointList)
-			{
-				if (oldBP.line == line)
-					id = oldBP.id;
-			}
-
-			if (id == -1)
-				id = this.nextBreakpointId++;
-
-			let clientBreak = <DebugProtocol.Breakpoint> {
-				id: id,
-				verified: true,
-				line: line
-			}
-			clientBreakpoints.push(clientBreak);
-
-			let breakpoint = <ASBreakpoint> { id: clientBreak.id, line: line };
-			breakpointList.push(breakpoint);
-
-			if(unreal.connected)
-				unreal.setBreakpoint(breakpoint.id, debugPath, line);
-		}
-
-		this.breakpoints.set(clientPath, breakpointList);
-
-		response.body = {
-			breakpoints: clientBreakpoints
-		};
-		this.sendResponse(response);
-	}
-
-	protected receiveBreakpoint(msg : unreal.Message)
-	{
-		let filename = msg.readString();
-		let line = msg.readInt();
-		let id = msg.readInt();
-
-		let breakpointList = this.getBreakpointList(filename);
-
-		// If our line number has changed, but we are overlapping an existing breakpoint,
-		// we should delete the new breakpoint.
-		let overlapsExistingBreakpoint = false;
-		for (let i = 0; i < breakpointList.length; ++i)
-		{
-			let bp = breakpointList[i];
-			if (bp.id != id && bp.line == line)
-			{
-				overlapsExistingBreakpoint = true;
-				break;
-			}
-		}
-
-		// For some reason, doing multiple sendEvent calls at once
-		// confuses visual studio code (?). So we spread them out
-		// by a few ms so it can deal with it.
-		let timeout = 1;
-
-		let adapter = this;
-		for (let i = 0; i < breakpointList.length; ++i)
-		{
-			let bp = breakpointList[i];
-			if (bp.id == id)
-			{
-				if (overlapsExistingBreakpoint)
-				{
-					// We created a breakpoint that was moved to a line that already has a breakpoint,
-					// so just remove the one we created.
-					breakpointList.splice(i, 1);
-					setTimeout(function()
-					{
-						adapter.sendEvent(new BreakpointEvent('removed', <DebugProtocol.Breakpoint>{ verified: false, id: bp.id }));
-					}, timeout++);
-				}
-				else if (line == -1)
-				{
-					// No code existed at this line, so show it as an unverified breakpoint
-					breakpointList.splice(i, 1);
-					setTimeout(function()
-					{
-						adapter.sendEvent(new BreakpointEvent('changed', <DebugProtocol.Breakpoint>{ verified: false, id: bp.id, line: bp.line }));
-					}, timeout++);
-				}
-				else
-				{
-					// The breakpoint was moved to a different line that actually has code on it, send a change back to the UI
-					bp.line = line;
-					setTimeout(function()
-					{
-						adapter.sendEvent(new BreakpointEvent('changed', <DebugProtocol.Breakpoint>{ verified: true, id: bp.id, line: bp.line }));
-					}, timeout++);
-				}
-
-				break;
-			}
-		}
-
-		this.breakpoints.set(filename, breakpointList);
-	}
-
-	protected setExceptionBreakPointsRequest(response: DebugProtocol.SetExceptionBreakpointsResponse, args: DebugProtocol.SetExceptionBreakpointsArguments)
-	{
-		unreal.sendBreakOptions(args.filters);
-		this.sendResponse(response);
-	}
-
-	protected threadsRequest(response: DebugProtocol.ThreadsResponse): void
-	{
-		// runtime supports now threads so just return a default thread.
-		response.body = {
-			threads: [
-				new Thread(ASDebugSession.THREAD_ID, "Unreal Editor")
-			]
-		};
-		this.sendResponse(response);
-	}
-
-
-	waitingTraces : Array<DebugProtocol.StackTraceResponse>;
-
-	protected stackTraceRequest(response: DebugProtocol.StackTraceResponse, args: DebugProtocol.StackTraceArguments) : void
-	{
-		unreal.sendRequestCallStack();
-
-		if(!this.waitingTraces)
-			this.waitingTraces = new Array<DebugProtocol.StackTraceResponse>();
-
-		this.waitingTraces.push(response);
-	}
-
-	protected receiveCallStack(msg : unreal.Message)
-	{
-		let stack = new Array<StackFrame>();
-
-		let count = msg.readInt();
-		for(let i = 0; i < count; ++i)
-		{
-			let name = msg.readString().replace(/_Implementation$/, "");
-			let source = this.createSource(msg.readString());
-			let line = msg.readInt();
-
-			let frame = new StackFrame(i, name, source, line, 1);
-			stack.push(frame);
-		}
-
-		if(stack.length == 0)
-		{
-			stack.push(new StackFrame(0, "No CallStack", this.createSource(""), 1));
-		}
-
-		if (this.waitingTraces && this.waitingTraces.length > 0)
-		{
-			let response = this.waitingTraces[0];
-			this.waitingTraces.splice(0, 1);
-
-			response.body = {
-				stackFrames: stack,
-				totalFrames: stack.length,
-			};
-
-			this.sendResponse(response);
-		}
-	}
-
-	protected scopesRequest(response: DebugProtocol.ScopesResponse, args: DebugProtocol.ScopesArguments) : void
-	{
-		const frameReference = args.frameId;
-		const scopes = new Array<Scope>();
-		scopes.push(new Scope("Variables", this._variableHandles.create(frameReference+":%local%"), false));
-		scopes.push(new Scope("this", this._variableHandles.create(frameReference+":%this%"), false));
-		scopes.push(new Scope("Globals", this._variableHandles.create(frameReference+":%module%"), false));
-
-		response.body = {
-			scopes: scopes
-		};
-		this.sendResponse(response);
-	}
-
-	waitingVariableRequests : Array<any>;
-
-	protected variablesRequest(response: DebugProtocol.VariablesResponse, args: DebugProtocol.VariablesArguments) : void
-	{
-		const id = this._variableHandles.get(args.variablesReference);
-		unreal.sendRequestVariables(id);
-
-		if(!this.waitingVariableRequests)
-			this.waitingVariableRequests = new Array<any>();
-
-		this.waitingVariableRequests.push({
-			response: response,
-			id: id,
-		});
-	}
-
-	combineExpression(expr : string, variable : string) : string
-	{
-		if(variable.startsWith("[") && variable.endsWith("]"))
-			return expr + variable;
-
-		return expr + "." + variable;
-	}
-
-	protected receiveVariables(msg : unreal.Message)
-	{
-		let id = "";
-		if (this.waitingVariableRequests && this.waitingVariableRequests.length > 0)
-		{
-			id = this.waitingVariableRequests[0].id;
-		}
-
-		let variables = new Array<DebugProtocol.Variable>();
-
-		let count = msg.readInt();
-		for(let i = 0; i < count; ++i)
-		{
-			let name = msg.readString();
-			let value = msg.readString();
-			let type = msg.readString();
-			let bHasMembers = msg.readBool();
-			let hint = <DebugProtocol.VariablePresentationHint>{};
-
-			let evalName = this.combineExpression(id, name);
-
-			let varRef = 0;
-			if (bHasMembers)
-				varRef = this._variableHandles.create(evalName);
-
-			if (name.endsWith("$"))
-			{
-				name = name.substr(0, name.length-1);
-				hint.kind = 'method';
-			}
-			else if (name.startsWith("[") && name.endsWith("]"))
-			{
-				hint.kind = 'data';
-			}
-
-			let variable = {
-				name: name,
-				type: type,
-				value: value,
-				presentationHint: hint,
-				variablesReference: varRef,
-				evaluateName: evalName.replace(/^[0-9]+:%.*%./g, ""),
-			};
-
-			variables.push(variable);
-		}
-
-		if (this.waitingVariableRequests && this.waitingVariableRequests.length > 0)
-		{
-			let response = this.waitingVariableRequests[0].response;
-			this.waitingVariableRequests.splice(0, 1);
-
-			response.body = {
-				variables: variables,
-			};
-
-			this.sendResponse(response);
-		}
-	}
-
-		protected continueRequest(response: DebugProtocol.ContinueResponse, args: DebugProtocol.ContinueArguments) : void
-		{
-		unreal.sendContinue();
-		this.sendResponse(response);
-	}
-
-	protected receiveContinued()
-	{
-		this.sendEvent(new ContinuedEvent(ASDebugSession.THREAD_ID));
-	}
-
-	protected receiveClosed()
-	{
-		this.sendEvent(new TerminatedEvent());
-	}
-
-	protected pauseRequest(response: DebugProtocol.PauseResponse, args: DebugProtocol.PauseArguments): void
-	{
-		unreal.sendPause();
-		this.sendResponse(response);
-	}
-
-	previousException : string;
-	protected receiveStopped(msg : unreal.Message)
-	{
-		let Reason = msg.readString();
-		let Description = msg.readString();
-		let Text = msg.readString();
-
-		if(Text.length != 0 && Reason == 'exception')
-		{
-			this.previousException = Text;
-			this.sendEvent(new StoppedEvent(Reason, ASDebugSession.THREAD_ID, Text));
-		}
-		else
-		{
-			this.previousException = null;
-			this.sendEvent(new StoppedEvent(Reason, ASDebugSession.THREAD_ID));
-		}
-	}
-
-	protected exceptionInfoRequest(response: DebugProtocol.ExceptionInfoResponse, args: DebugProtocol.ExceptionInfoArguments): void
-	{
-		if(!this.previousException)
-		{
-			this.sendResponse(response);
-			return;
-		}
-
-		response.body = {
-			exceptionId: "",
-			breakMode: "unhandled",
-			description: this.previousException,
-		};
-		this.sendResponse(response);
-	}
-
-		protected nextRequest(response: DebugProtocol.NextResponse, args: DebugProtocol.NextArguments) : void
-		{
-		unreal.sendStepOver();
-		this.sendResponse(response);
-	}
-
-	protected stepInRequest(response: DebugProtocol.StepInResponse, args: DebugProtocol.StepInArguments): void
-	{
-		unreal.sendStepIn();
-		this.sendResponse(response);
-	}
-
-	protected stepOutRequest(response: DebugProtocol.StepOutResponse, args: DebugProtocol.StepOutArguments): void
-	{
-		unreal.sendStepOut();
-		this.sendResponse(response);
-	}
-
-	protected restartRequest(response: DebugProtocol.RestartResponse, args: DebugProtocol.RestartArguments): void
-	{
-		//unreal.sendEngineBreak();
-		this.sendResponse(response);
-	}
-
-	waitingEvaluateRequests : Array<any>;
-		protected evaluateRequest(response: DebugProtocol.EvaluateResponse, args: DebugProtocol.EvaluateArguments) : void
-		{
-		unreal.sendRequestEvaluate(args.expression, args.frameId);
-
-		if(!this.waitingEvaluateRequests)
-			this.waitingEvaluateRequests = new Array<any>();
-
-		this.waitingEvaluateRequests.push({
-			expression: args.expression,
-			frameId: args.frameId,
-			response: response,
-		});
-	}
-
-	protected receiveEvaluate(msg : unreal.Message)
-	{
-		let id = "";
-		if (this.waitingEvaluateRequests && this.waitingEvaluateRequests.length > 0)
-		{
-			id = this.waitingEvaluateRequests[0].expression;
-			if(!/^[0-9]+:/.test(id))
-			{
-				id = this.waitingEvaluateRequests[0].frameId + ":" + id;
-			}
-		}
-
-		let name = msg.readString();
-		let value = msg.readString();
-		let type = msg.readString();
-		let bHasMembers = msg.readBool();
-
-		if (this.waitingEvaluateRequests && this.waitingEvaluateRequests.length > 0)
-		{
-			let response = this.waitingEvaluateRequests[0].response;
-			this.waitingEvaluateRequests.splice(0, 1);
-
-			if(value.length == 0)
-			{
-
-			}
-			else
-			{
-				response.body = {
-					result: value,
-					variablesReference: bHasMembers ? this._variableHandles.create(id) : 0,
-				};
-			}
-			this.sendResponse(response);
-		}
-	}
-
-	//---- helpers
-		private createSource(filePath: string): Source
-		{
-		return new Source(basename(filePath), this.convertDebuggerPathToClient(filePath), undefined, undefined, 'as-adapter-data');
-	}
+    // we don't support multiple threads, so we can use a hardcoded ID for the default thread
+    private static THREAD_ID = 1;
+
+    private breakpoints = new Map<string, ASBreakpoint[]>();
+    private nextBreakpointId = 1;
+
+    private _variableHandles = new Handles<string>();
+
+    private _configurationDone = new Subject();
+
+    port = 27099;
+
+    /**
+     * Creates a new debug adapter that is used for one debug session.
+     * We configure the default implementation of a debug adapter here.
+     */
+    public constructor()
+    {
+        super("angelscript-debug");
+
+        this.setDebuggerLinesStartAt1(true);
+        this.setDebuggerColumnsStartAt1(true);
+
+        unreal.events.removeAllListeners();
+        unreal.events.on("CallStack", (msg : unreal.Message) => {
+            this.receiveCallStack(msg);
+        });
+
+        unreal.events.on("Stopped", (msg : unreal.Message) => {
+            this.receiveStopped(msg);
+        });
+
+        unreal.events.on("Continued", (msg : unreal.Message) => {
+            this.receiveContinued();
+        });
+
+        unreal.events.on("Variables", (msg : unreal.Message) => {
+            this.receiveVariables(msg);
+        });
+
+        unreal.events.on("Evaluate", (msg : unreal.Message) => {
+            this.receiveEvaluate(msg);
+        });
+
+        unreal.events.on("BreakFilters", (msg : unreal.Message) => {
+            this.receiveBreakFilters(msg);
+        });
+
+        unreal.events.on("Closed", () => {
+            this.receiveClosed();
+        });
+
+        unreal.events.on("SetBreakpoint", (msg : unreal.Message) => {
+            this.receiveBreakpoint(msg);
+        });
+    }
+
+    /**
+     * The 'initialize' request is the first request called by the frontend
+     * to interrogate the features the debug adapter provides.
+     */
+
+    waitingInitializeResponse : DebugProtocol.InitializeResponse;
+    protected initializeRequest(response: DebugProtocol.InitializeResponse, args: DebugProtocol.InitializeRequestArguments) : void
+    {
+        // build and return the capabilities of this debug adapter:
+        response.body = response.body || {};
+
+        // the adapter implements the configurationDoneRequest.
+        response.body.supportsConfigurationDoneRequest = true;
+
+        // make VS Code to use 'evaluate' when hovering over source
+        response.body.supportsEvaluateForHovers = true;
+        response.body.supportsExceptionInfoRequest = true;
+
+        unreal.connect(this.port);
+        unreal.sendRequestBreakFilters();
+
+        this.waitingInitializeResponse = response;
+    }
+
+    receiveBreakFilters(msg : unreal.Message) : void
+    {
+        this.waitingInitializeResponse.body.exceptionBreakpointFilters = [];
+        let count = msg.readInt();
+        for (let i = 0; i < count; ++i)
+        {
+            let filter = msg.readString();
+            let filterTitle = msg.readString();
+
+            this.waitingInitializeResponse.body.exceptionBreakpointFilters.push(
+                <DebugProtocol.ExceptionBreakpointsFilter> {
+                    filter: filter,
+                    label: filterTitle,
+                    default: true,
+                },
+            );
+        }
+
+        unreal.disconnect();
+
+        this.sendResponse(this.waitingInitializeResponse);
+
+        // since this debug adapter can accept configuration requests like 'setASBreakpoint' at any time,
+        // we request them early by sending an 'initializeRequest' to the frontend.
+        // The frontend will end the configuration sequence by calling 'configurationDone' request.
+        this.sendEvent(new InitializedEvent());
+    }
+
+    /**
+     * Called at the end of the configuration sequence.
+     * Indicates that all breakpoints etc. have been sent to the DA and that the 'launch' can start.
+     */
+    protected configurationDoneRequest(response: DebugProtocol.ConfigurationDoneResponse, args: DebugProtocol.ConfigurationDoneArguments) : void
+    {
+        super.configurationDoneRequest(response, args);
+
+        // notify the launchRequest that configuration has finished
+        this._configurationDone.notify();
+    }
+
+    protected async launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments)
+    {
+        // make sure to 'Stop' the buffered logging if 'trace' is not set
+        logger.setup(args.trace ? Logger.LogLevel.Verbose : Logger.LogLevel.Stop, false);
+
+        unreal.connect(args.port !== undefined ? args.port : this.port);
+        unreal.sendStartDebugging();
+
+        for (let clientPath of this.breakpoints.keys())
+        {
+            let breakpointList = this.getBreakpointList(clientPath);
+            if (breakpointList.length != 0)
+            {
+                const debugPath = this.convertClientPathToDebugger(clientPath);
+                unreal.clearBreakpoints(debugPath);
+
+                for(let breakpoint of breakpointList)
+                {
+                    unreal.setBreakpoint(breakpoint.id, debugPath, breakpoint.line);
+                }
+            }
+        }
+
+        // wait until configuration has finished (and configurationDoneRequest has been called)
+        await this._configurationDone.wait(1000);
+
+        this.sendResponse(response);
+    }
+
+    protected disconnectRequest(response: DebugProtocol.DisconnectResponse, args: DebugProtocol.DisconnectArguments): void
+    {
+        unreal.sendStopDebugging();
+        unreal.disconnect();
+
+        this.sendResponse(response);
+    }
+
+    protected getBreakpointList(path : string) : Array<ASBreakpoint>
+    {
+        let breakpointList = this.breakpoints.get(path);
+        if(!breakpointList)
+        {
+            breakpointList = new Array<ASBreakpoint>();
+            this.breakpoints.set(path, breakpointList);
+        }
+        return breakpointList;
+    }
+
+    protected setBreakPointsRequest(response: DebugProtocol.SetBreakpointsResponse, args: DebugProtocol.SetBreakpointsArguments) : void
+    {
+        const clientLines = args.lines || [];
+        const clientPath = <string>args.source.path;
+        const debugPath = this.convertClientPathToDebugger(clientPath);
+
+        let clientBreakpoints = new Array<DebugProtocol.Breakpoint>();
+        let oldBreakpointList = this.getBreakpointList(clientPath);
+        let breakpointList = new Array<ASBreakpoint>();
+
+        if(unreal.connected)
+            unreal.clearBreakpoints(debugPath);
+
+        for (let line of clientLines)
+        {
+            let id = -1;
+            for (let oldBP of oldBreakpointList)
+            {
+                if (oldBP.line == line)
+                    id = oldBP.id;
+            }
+
+            if (id == -1)
+                id = this.nextBreakpointId++;
+
+            let clientBreak = <DebugProtocol.Breakpoint> {
+                id: id,
+                verified: true,
+                line: line
+            }
+            clientBreakpoints.push(clientBreak);
+
+            let breakpoint = <ASBreakpoint> { id: clientBreak.id, line: line };
+            breakpointList.push(breakpoint);
+
+            if(unreal.connected)
+                unreal.setBreakpoint(breakpoint.id, debugPath, line);
+        }
+
+        this.breakpoints.set(clientPath, breakpointList);
+
+        response.body = {
+            breakpoints: clientBreakpoints
+        };
+        this.sendResponse(response);
+    }
+
+    protected receiveBreakpoint(msg : unreal.Message)
+    {
+        let filename = msg.readString();
+        let line = msg.readInt();
+        let id = msg.readInt();
+
+        let breakpointList = this.getBreakpointList(filename);
+
+        // If our line number has changed, but we are overlapping an existing breakpoint,
+        // we should delete the new breakpoint.
+        let overlapsExistingBreakpoint = false;
+        for (let i = 0; i < breakpointList.length; ++i)
+        {
+            let bp = breakpointList[i];
+            if (bp.id != id && bp.line == line)
+            {
+                overlapsExistingBreakpoint = true;
+                break;
+            }
+        }
+
+        // For some reason, doing multiple sendEvent calls at once
+        // confuses visual studio code (?). So we spread them out
+        // by a few ms so it can deal with it.
+        let timeout = 1;
+
+        let adapter = this;
+        for (let i = 0; i < breakpointList.length; ++i)
+        {
+            let bp = breakpointList[i];
+            if (bp.id == id)
+            {
+                if (overlapsExistingBreakpoint)
+                {
+                    // We created a breakpoint that was moved to a line that already has a breakpoint,
+                    // so just remove the one we created.
+                    breakpointList.splice(i, 1);
+                    setTimeout(function()
+                    {
+                        adapter.sendEvent(new BreakpointEvent('removed', <DebugProtocol.Breakpoint>{ verified: false, id: bp.id }));
+                    }, timeout++);
+                }
+                else if (line == -1)
+                {
+                    // No code existed at this line, so show it as an unverified breakpoint
+                    breakpointList.splice(i, 1);
+                    setTimeout(function()
+                    {
+                        adapter.sendEvent(new BreakpointEvent('changed', <DebugProtocol.Breakpoint>{ verified: false, id: bp.id, line: bp.line }));
+                    }, timeout++);
+                }
+                else
+                {
+                    // The breakpoint was moved to a different line that actually has code on it, send a change back to the UI
+                    bp.line = line;
+                    setTimeout(function()
+                    {
+                        adapter.sendEvent(new BreakpointEvent('changed', <DebugProtocol.Breakpoint>{ verified: true, id: bp.id, line: bp.line }));
+                    }, timeout++);
+                }
+
+                break;
+            }
+        }
+
+        this.breakpoints.set(filename, breakpointList);
+    }
+
+    protected setExceptionBreakPointsRequest(response: DebugProtocol.SetExceptionBreakpointsResponse, args: DebugProtocol.SetExceptionBreakpointsArguments)
+    {
+        unreal.sendBreakOptions(args.filters);
+        this.sendResponse(response);
+    }
+
+    protected threadsRequest(response: DebugProtocol.ThreadsResponse): void
+    {
+        // runtime supports now threads so just return a default thread.
+        response.body = {
+            threads: [
+                new Thread(ASDebugSession.THREAD_ID, "Unreal Editor")
+            ]
+        };
+        this.sendResponse(response);
+    }
+
+
+    waitingTraces : Array<DebugProtocol.StackTraceResponse>;
+
+    protected stackTraceRequest(response: DebugProtocol.StackTraceResponse, args: DebugProtocol.StackTraceArguments) : void
+    {
+        unreal.sendRequestCallStack();
+
+        if(!this.waitingTraces)
+            this.waitingTraces = new Array<DebugProtocol.StackTraceResponse>();
+
+        this.waitingTraces.push(response);
+    }
+
+    protected receiveCallStack(msg : unreal.Message)
+    {
+        let stack = new Array<StackFrame>();
+
+        let count = msg.readInt();
+        for(let i = 0; i < count; ++i)
+        {
+            let name = msg.readString().replace(/_Implementation$/, "");
+            let source = this.createSource(msg.readString());
+            let line = msg.readInt();
+
+            let frame = new StackFrame(i, name, source, line, 1);
+            stack.push(frame);
+        }
+
+        if(stack.length == 0)
+        {
+            stack.push(new StackFrame(0, "No CallStack", this.createSource(""), 1));
+        }
+
+        if (this.waitingTraces && this.waitingTraces.length > 0)
+        {
+            let response = this.waitingTraces[0];
+            this.waitingTraces.splice(0, 1);
+
+            response.body = {
+                stackFrames: stack,
+                totalFrames: stack.length,
+            };
+
+            this.sendResponse(response);
+        }
+    }
+
+    protected scopesRequest(response: DebugProtocol.ScopesResponse, args: DebugProtocol.ScopesArguments) : void
+    {
+        const frameReference = args.frameId;
+        const scopes = new Array<Scope>();
+        scopes.push(new Scope("Variables", this._variableHandles.create(frameReference+":%local%"), false));
+        scopes.push(new Scope("this", this._variableHandles.create(frameReference+":%this%"), false));
+        scopes.push(new Scope("Globals", this._variableHandles.create(frameReference+":%module%"), false));
+
+        response.body = {
+            scopes: scopes
+        };
+        this.sendResponse(response);
+    }
+
+    waitingVariableRequests : Array<any>;
+
+    protected variablesRequest(response: DebugProtocol.VariablesResponse, args: DebugProtocol.VariablesArguments) : void
+    {
+        const id = this._variableHandles.get(args.variablesReference);
+        unreal.sendRequestVariables(id);
+
+        if(!this.waitingVariableRequests)
+            this.waitingVariableRequests = new Array<any>();
+
+        this.waitingVariableRequests.push({
+            response: response,
+            id: id,
+        });
+    }
+
+    combineExpression(expr : string, variable : string) : string
+    {
+        if(variable.startsWith("[") && variable.endsWith("]"))
+            return expr + variable;
+
+        return expr + "." + variable;
+    }
+
+    protected receiveVariables(msg : unreal.Message)
+    {
+        let id = "";
+        if (this.waitingVariableRequests && this.waitingVariableRequests.length > 0)
+        {
+            id = this.waitingVariableRequests[0].id;
+        }
+
+        let variables = new Array<DebugProtocol.Variable>();
+
+        let count = msg.readInt();
+        for(let i = 0; i < count; ++i)
+        {
+            let name = msg.readString();
+            let value = msg.readString();
+            let type = msg.readString();
+            let bHasMembers = msg.readBool();
+            let hint = <DebugProtocol.VariablePresentationHint>{};
+
+            let evalName = this.combineExpression(id, name);
+
+            let varRef = 0;
+            if (bHasMembers)
+                varRef = this._variableHandles.create(evalName);
+
+            if (name.endsWith("$"))
+            {
+                name = name.substr(0, name.length-1);
+                hint.kind = 'method';
+            }
+            else if (name.startsWith("[") && name.endsWith("]"))
+            {
+                hint.kind = 'data';
+            }
+
+            let variable = {
+                name: name,
+                type: type,
+                value: value,
+                presentationHint: hint,
+                variablesReference: varRef,
+                evaluateName: evalName.replace(/^[0-9]+:%.*%./g, ""),
+            };
+
+            variables.push(variable);
+        }
+
+        if (this.waitingVariableRequests && this.waitingVariableRequests.length > 0)
+        {
+            let response = this.waitingVariableRequests[0].response;
+            this.waitingVariableRequests.splice(0, 1);
+
+            response.body = {
+                variables: variables,
+            };
+
+            this.sendResponse(response);
+        }
+    }
+
+        protected continueRequest(response: DebugProtocol.ContinueResponse, args: DebugProtocol.ContinueArguments) : void
+        {
+        unreal.sendContinue();
+        this.sendResponse(response);
+    }
+
+    protected receiveContinued()
+    {
+        this.sendEvent(new ContinuedEvent(ASDebugSession.THREAD_ID));
+    }
+
+    protected receiveClosed()
+    {
+        this.sendEvent(new TerminatedEvent());
+    }
+
+    protected pauseRequest(response: DebugProtocol.PauseResponse, args: DebugProtocol.PauseArguments): void
+    {
+        unreal.sendPause();
+        this.sendResponse(response);
+    }
+
+    previousException : string;
+    protected receiveStopped(msg : unreal.Message)
+    {
+        let Reason = msg.readString();
+        let Description = msg.readString();
+        let Text = msg.readString();
+
+        if(Text.length != 0 && Reason == 'exception')
+        {
+            this.previousException = Text;
+            this.sendEvent(new StoppedEvent(Reason, ASDebugSession.THREAD_ID, Text));
+        }
+        else
+        {
+            this.previousException = null;
+            this.sendEvent(new StoppedEvent(Reason, ASDebugSession.THREAD_ID));
+        }
+    }
+
+    protected exceptionInfoRequest(response: DebugProtocol.ExceptionInfoResponse, args: DebugProtocol.ExceptionInfoArguments): void
+    {
+        if(!this.previousException)
+        {
+            this.sendResponse(response);
+            return;
+        }
+
+        response.body = {
+            exceptionId: "",
+            breakMode: "unhandled",
+            description: this.previousException,
+        };
+        this.sendResponse(response);
+    }
+
+        protected nextRequest(response: DebugProtocol.NextResponse, args: DebugProtocol.NextArguments) : void
+        {
+        unreal.sendStepOver();
+        this.sendResponse(response);
+    }
+
+    protected stepInRequest(response: DebugProtocol.StepInResponse, args: DebugProtocol.StepInArguments): void
+    {
+        unreal.sendStepIn();
+        this.sendResponse(response);
+    }
+
+    protected stepOutRequest(response: DebugProtocol.StepOutResponse, args: DebugProtocol.StepOutArguments): void
+    {
+        unreal.sendStepOut();
+        this.sendResponse(response);
+    }
+
+    protected restartRequest(response: DebugProtocol.RestartResponse, args: DebugProtocol.RestartArguments): void
+    {
+        //unreal.sendEngineBreak();
+        this.sendResponse(response);
+    }
+
+    waitingEvaluateRequests : Array<any>;
+        protected evaluateRequest(response: DebugProtocol.EvaluateResponse, args: DebugProtocol.EvaluateArguments) : void
+        {
+        unreal.sendRequestEvaluate(args.expression, args.frameId);
+
+        if(!this.waitingEvaluateRequests)
+            this.waitingEvaluateRequests = new Array<any>();
+
+        this.waitingEvaluateRequests.push({
+            expression: args.expression,
+            frameId: args.frameId,
+            response: response,
+        });
+    }
+
+    protected receiveEvaluate(msg : unreal.Message)
+    {
+        let id = "";
+        if (this.waitingEvaluateRequests && this.waitingEvaluateRequests.length > 0)
+        {
+            id = this.waitingEvaluateRequests[0].expression;
+            if(!/^[0-9]+:/.test(id))
+            {
+                id = this.waitingEvaluateRequests[0].frameId + ":" + id;
+            }
+        }
+
+        let name = msg.readString();
+        let value = msg.readString();
+        let type = msg.readString();
+        let bHasMembers = msg.readBool();
+
+        if (this.waitingEvaluateRequests && this.waitingEvaluateRequests.length > 0)
+        {
+            let response = this.waitingEvaluateRequests[0].response;
+            this.waitingEvaluateRequests.splice(0, 1);
+
+            if(value.length == 0)
+            {
+
+            }
+            else
+            {
+                response.body = {
+                    result: value,
+                    variablesReference: bHasMembers ? this._variableHandles.create(id) : 0,
+                };
+            }
+            this.sendResponse(response);
+        }
+    }
+
+    //---- helpers
+        private createSource(filePath: string): Source
+        {
+        return new Source(basename(filePath), this.convertDebuggerPathToClient(filePath), undefined, undefined, 'as-adapter-data');
+    }
 }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -23,158 +23,158 @@ const ProvideInlineValuesRequest: RequestType<TextDocumentPositionParams, any[],
 
 export function activate(context: ExtensionContext) {
 
-	// The server is implemented in node
-	let serverModule = context.asAbsolutePath(path.join('language-server', 'out', 'server.js'));
-	// The debug options for the server
-	let debugOptions = { execArgv: ["--nolazy", "--inspect=6009"] };
-	
-	// If the extension is launched in debug mode then the debug server options are used
-	// Otherwise the run options are used
-	let serverOptions: ServerOptions = {
-		run : { module: serverModule, transport: TransportKind.ipc },
-		debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
-	}
-	
-	// Options to control the language client
-	let clientOptions: LanguageClientOptions = {
-		// Register the server for plain text documents
-		documentSelector: [{scheme: 'file', language: 'angelscript'}],
-		synchronize: {
-			fileEvents: workspace.createFileSystemWatcher('**/*.as'),
+    // The server is implemented in node
+    let serverModule = context.asAbsolutePath(path.join('language-server', 'out', 'server.js'));
+    // The debug options for the server
+    let debugOptions = { execArgv: ["--nolazy", "--inspect=6009"] };
+
+    // If the extension is launched in debug mode then the debug server options are used
+    // Otherwise the run options are used
+    let serverOptions: ServerOptions = {
+        run : { module: serverModule, transport: TransportKind.ipc },
+        debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
+    }
+
+    // Options to control the language client
+    let clientOptions: LanguageClientOptions = {
+        // Register the server for plain text documents
+        documentSelector: [{scheme: 'file', language: 'angelscript'}],
+        synchronize: {
+            fileEvents: workspace.createFileSystemWatcher('**/*.as'),
             configurationSection: "UnrealAngelscript",
-		}
-	}
+        }
+    }
 
-	console.log("Activate angelscript extension");
-	
-	// Create the language client and start the client.
-	let client = new LanguageClient('angelscriptLanguageServer', 'Angelscript Language Server', serverOptions, clientOptions)
-	let started_client = client.start();
+    console.log("Activate angelscript extension");
 
-	// register a configuration provider for 'mock' debug type
-	const provider = new ASConfigurationProvider();
-	context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('angelscript', provider));
-	context.subscriptions.push(provider);
+    // Create the language client and start the client.
+    let client = new LanguageClient('angelscriptLanguageServer', 'Angelscript Language Server', serverOptions, clientOptions)
+    let started_client = client.start();
+
+    // register a configuration provider for 'mock' debug type
+    const provider = new ASConfigurationProvider();
+    context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('angelscript', provider));
+    context.subscriptions.push(provider);
 
     let inlineValuesProvider = new ASInlineValuesProvider();
     inlineValuesProvider.languageClient = client;
-	context.subscriptions.push(vscode.languages.registerInlineValuesProvider('angelscript', inlineValuesProvider));
+    context.subscriptions.push(vscode.languages.registerInlineValuesProvider('angelscript', inlineValuesProvider));
 
-	// Register the 'copy import path' command
-	let copyImportPath = vscode.commands.registerCommand('angelscript.copyImportPath', (selectedFile : any) => {
-		let relPath = vscode.workspace.asRelativePath(selectedFile, false).trim();
+    // Register the 'copy import path' command
+    let copyImportPath = vscode.commands.registerCommand('angelscript.copyImportPath', (selectedFile : any) => {
+        let relPath = vscode.workspace.asRelativePath(selectedFile, false).trim();
 
-		let extIndex = relPath.indexOf(".as");
-		if (extIndex != -1)
-			relPath = relPath.substr(0, extIndex);
-		relPath = relPath.replace(/[\/\\]/g, ".");
+        let extIndex = relPath.indexOf(".as");
+        if (extIndex != -1)
+            relPath = relPath.substr(0, extIndex);
+        relPath = relPath.replace(/[\/\\]/g, ".");
 
-		copyPaste.copy(relPath);
-	});
+        copyPaste.copy(relPath);
+    });
 
-	context.subscriptions.push(copyImportPath);
+    context.subscriptions.push(copyImportPath);
 
-	// Register 'Go To Symbol'
-	let goToSymbol = vscode.commands.registerCommand('angelscript.goToSymbol', (location : any) => {
-		vscode.commands.executeCommand("editor.action.goToImplementation", location);
-	});
+    // Register 'Go To Symbol'
+    let goToSymbol = vscode.commands.registerCommand('angelscript.goToSymbol', (location : any) => {
+        vscode.commands.executeCommand("editor.action.goToImplementation", location);
+    });
 
-	context.subscriptions.push(goToSymbol);
+    context.subscriptions.push(goToSymbol);
 
-	// Register 'Add Import To'
-	let addImportTo = vscode.commands.registerCommand('angelscript.addImportTo', (location : any) => {
-		var editor = vscode.window.activeTextEditor;
-		
-		var params: TextDocumentPositionParams = {
-			position: editor.selection.anchor,
-			textDocument: { uri: editor.document.uri.toString(false) }
-		};
-		
-		client.sendRequest(GetModuleForSymbolRequest, params).then((result: string) => {
-			if (result == "-")
-			{
-				return
-			}
-			else if (result == "")
-			{
-				// Find word under cursor
-				let wordRange = editor.document.getWordRangeAtPosition(editor.selection.anchor);
-				let word = editor.document.getText(wordRange);
+    // Register 'Add Import To'
+    let addImportTo = vscode.commands.registerCommand('angelscript.addImportTo', (location : any) => {
+        var editor = vscode.window.activeTextEditor;
 
-				vscode.window.showErrorMessage(`The symbol '${word}' was not found`);
-				return;
-			}
-			else
-			{
-				// Module found!
-				let lines : string[] = editor.document.getText().split("\n");
-				let lastImportLine = 0;
-				let hasEmptyLine = false;
-				let importRegex = /\s*import\s+([A-Za-z0-9_]+(\.[A-Za-z0-9_]+)*);/;
+        var params: TextDocumentPositionParams = {
+            position: editor.selection.anchor,
+            textDocument: { uri: editor.document.uri.toString(false) }
+        };
 
-				// Find if the module is already imported, or the position to append the new import
-				for(let i = 0; i < lines.length; ++i)
-				{
-					let match = importRegex.exec(lines[i]);
-					if (match)
-					{
-						if (match[1] == result)
-						{
-							console.log(`${result} is already included`);
-							vscode.window.showInformationMessage(`'${result}' is already imported`);
-							return;
-						}
+        client.sendRequest(GetModuleForSymbolRequest, params).then((result: string) => {
+            if (result == "-")
+            {
+                return
+            }
+            else if (result == "")
+            {
+                // Find word under cursor
+                let wordRange = editor.document.getWordRangeAtPosition(editor.selection.anchor);
+                let word = editor.document.getText(wordRange);
 
-						lastImportLine = i + 1;
-						hasEmptyLine = false;
-					}
-					else if (lines[i].trim().length != 0)
-					{
-						// Break if we find a line that's not empty, signalling the end of the import-block
-						break;
-					}
-					else
-					{
-						hasEmptyLine = true;
-					}
-				}
+                vscode.window.showErrorMessage(`The symbol '${word}' was not found`);
+                return;
+            }
+            else
+            {
+                // Module found!
+                let lines : string[] = editor.document.getText().split("\n");
+                let lastImportLine = 0;
+                let hasEmptyLine = false;
+                let importRegex = /\s*import\s+([A-Za-z0-9_]+(\.[A-Za-z0-9_]+)*);/;
 
-				let insertString = "import "+result+";\n";
-				if (!hasEmptyLine)
-					insertString += "\n";
+                // Find if the module is already imported, or the position to append the new import
+                for(let i = 0; i < lines.length; ++i)
+                {
+                    let match = importRegex.exec(lines[i]);
+                    if (match)
+                    {
+                        if (match[1] == result)
+                        {
+                            console.log(`${result} is already included`);
+                            vscode.window.showInformationMessage(`'${result}' is already imported`);
+                            return;
+                        }
 
-				editor.edit((edit: vscode.TextEditorEdit) => {
-					edit.insert(new vscode.Position(lastImportLine, 0), insertString);
-				});
-			}
-		});
-	});
+                        lastImportLine = i + 1;
+                        hasEmptyLine = false;
+                    }
+                    else if (lines[i].trim().length != 0)
+                    {
+                        // Break if we find a line that's not empty, signalling the end of the import-block
+                        break;
+                    }
+                    else
+                    {
+                        hasEmptyLine = true;
+                    }
+                }
 
-	context.subscriptions.push(addImportTo);
+                let insertString = "import "+result+";\n";
+                if (!hasEmptyLine)
+                    insertString += "\n";
 
-	let quickOpenImport = vscode.commands.registerCommand('angelscript.quickOpenImport', () => {
-		let activeEditor = vscode.window.activeTextEditor;
-		if (activeEditor != null) {
-			let line_number = activeEditor.selection.active.line;
-			let text_line = activeEditor.document.lineAt(line_number);
-			let text = text_line.text.split(' ');
-			if (text.length != 0 && text[0] === "import") {
-				let path = text[1].slice(0, -1).split('.').join('\\');
-				vscode.commands.executeCommand('workbench.action.quickOpen', path);
-				return;
-			}
-		}
-		vscode.commands.executeCommand('workbench.action.quickOpen', '');
-	});
-	context.subscriptions.push(quickOpenImport);
+                editor.edit((edit: vscode.TextEditorEdit) => {
+                    edit.insert(new vscode.Position(lastImportLine, 0), insertString);
+                });
+            }
+        });
+    });
 
-	let completionParen = vscode.commands.registerCommand('angelscript.paren', () =>
+    context.subscriptions.push(addImportTo);
+
+    let quickOpenImport = vscode.commands.registerCommand('angelscript.quickOpenImport', () => {
+        let activeEditor = vscode.window.activeTextEditor;
+        if (activeEditor != null) {
+            let line_number = activeEditor.selection.active.line;
+            let text_line = activeEditor.document.lineAt(line_number);
+            let text = text_line.text.split(' ');
+            if (text.length != 0 && text[0] === "import") {
+                let path = text[1].slice(0, -1).split('.').join('\\');
+                vscode.commands.executeCommand('workbench.action.quickOpen', path);
+                return;
+            }
+        }
+        vscode.commands.executeCommand('workbench.action.quickOpen', '');
+    });
+    context.subscriptions.push(quickOpenImport);
+
+    let completionParen = vscode.commands.registerCommand('angelscript.paren', () =>
     {
-		let activeEditor = vscode.window.activeTextEditor;
-		if (activeEditor != null)
+        let activeEditor = vscode.window.activeTextEditor;
+        if (activeEditor != null)
         {
-			let line_number = activeEditor.selection.active.line;
-			let text_line = activeEditor.document.lineAt(line_number);
+            let line_number = activeEditor.selection.active.line;
+            let text_line = activeEditor.document.lineAt(line_number);
 
             let char_number = activeEditor.selection.active.character;
             let char = text_line.text[char_number-1];
@@ -187,7 +187,7 @@ export function activate(context: ExtensionContext) {
             else if (char == '.')
             {
                 // Replace the single dot from the commit character with a call
-				activeEditor.edit((edit: vscode.TextEditorEdit) => {
+                activeEditor.edit((edit: vscode.TextEditorEdit) => {
                         edit.insert(new vscode.Position(line_number, char_number-1), "()");
                     },
                     {
@@ -196,7 +196,7 @@ export function activate(context: ExtensionContext) {
                     });
 
                 // Open suggestions again since the commit character dot did not act as a completion character dot
-				vscode.commands.executeCommand('editor.action.triggerSuggest');
+                vscode.commands.executeCommand('editor.action.triggerSuggest');
             }
             else if (char_number >= text_line.text.length || text_line.text[char_number] != '(')
             {
@@ -215,71 +215,71 @@ export function activate(context: ExtensionContext) {
                     });
 
                 // Open signature help popup since we skipped it by not typing the paren
-				vscode.commands.executeCommand('editor.action.triggerParameterHints');
+                vscode.commands.executeCommand('editor.action.triggerParameterHints');
             }
-		}
-	});
-	context.subscriptions.push(completionParen);
+        }
+    });
+    context.subscriptions.push(completionParen);
 
     let inlayHintsProvider = new ASInlayHintsProvider();
     inlayHintsProvider.lspClient = client;
 
     let inlaySubscription = vscode.languages.registerInlayHintsProvider('angelscript', inlayHintsProvider)
-	context.subscriptions.push(inlaySubscription);
+    context.subscriptions.push(inlaySubscription);
 
-	console.log("Done activating angelscript extension");
+    console.log("Done activating angelscript extension");
 }
 
 class ASConfigurationProvider implements vscode.DebugConfigurationProvider {
 
-	private _server?: Net.Server;
-	private _config?: DebugConfiguration;
+    private _server?: Net.Server;
+    private _config?: DebugConfiguration;
 
-	/**
-	 * Massage a debug configuration just before a debug session is being launched,
-	 * e.g. add all missing attributes to the debug configuration.
-	 */
-	resolveDebugConfiguration(folder: WorkspaceFolder | undefined, config: DebugConfiguration, token?: CancellationToken): ProviderResult<DebugConfiguration>
-	{
-		if (!config.type && !config.request && !config.name)
-		{
-			const editor = vscode.window.activeTextEditor;
-			if (editor && editor.document.languageId === 'angelscript' )
-			{
-				config.type = 'angelscript';
-				config.name = 'Debug Angelscript';
-				config.request = 'launch';
-				config.stopOnEntry = true;
-			}
-		}
+    /**
+     * Massage a debug configuration just before a debug session is being launched,
+     * e.g. add all missing attributes to the debug configuration.
+     */
+    resolveDebugConfiguration(folder: WorkspaceFolder | undefined, config: DebugConfiguration, token?: CancellationToken): ProviderResult<DebugConfiguration>
+    {
+        if (!config.type && !config.request && !config.name)
+        {
+            const editor = vscode.window.activeTextEditor;
+            if (editor && editor.document.languageId === 'angelscript' )
+            {
+                config.type = 'angelscript';
+                config.name = 'Debug Angelscript';
+                config.request = 'launch';
+                config.stopOnEntry = true;
+            }
+        }
 
-		let port = config.port;
-		if (EMBED_DEBUG_ADAPTER) {
-			// start port listener on launch of first debug session
-			// or if the port changed
-			if (!this._server || (this._server && port != this._config.port)) {
-				// start listening on a random port
-				this._server = Net.createServer(socket => {
-					const session = new ASDebugSession();
-					session.setRunAsServer(true);
-					if (port !== undefined)
-						session.port = port;
-					session.start(<NodeJS.ReadableStream>socket, socket);
-				}).listen(0);
-			}
+        let port = config.port;
+        if (EMBED_DEBUG_ADAPTER) {
+            // start port listener on launch of first debug session
+            // or if the port changed
+            if (!this._server || (this._server && port != this._config.port)) {
+                // start listening on a random port
+                this._server = Net.createServer(socket => {
+                    const session = new ASDebugSession();
+                    session.setRunAsServer(true);
+                    if (port !== undefined)
+                        session.port = port;
+                    session.start(<NodeJS.ReadableStream>socket, socket);
+                }).listen(0);
+            }
 
-			// make VS Code connect to debug server instead of launching debug adapter
-			//config.debugServer = this._server.address().port;
-		}
-		this._config = config;
-		return config;
-	}
+            // make VS Code connect to debug server instead of launching debug adapter
+            //config.debugServer = this._server.address().port;
+        }
+        this._config = config;
+        return config;
+    }
 
-	dispose() {
-		if (this._server) {
-			this._server.close();
-		}
-	}
+    dispose() {
+        if (this._server) {
+            this._server.close();
+        }
+    }
 }
 
 const AngelscriptInlayHintsRequest : RequestType<any, any[], void> = new RequestType<any, any[], void>('angelscript/inlayHints');
@@ -295,7 +295,7 @@ class ASInlayHintsProvider implements vscode.InlayHintsProvider
             start: range.start,
             end: range.end,
         };
-		return this.lspClient.sendRequest(AngelscriptInlayHintsRequest, params);
+        return this.lspClient.sendRequest(AngelscriptInlayHintsRequest, params);
     }
 };
 
@@ -305,12 +305,12 @@ class ASInlineValuesProvider implements vscode.InlineValuesProvider
 
     provideInlineValues(document: TextDocument, viewPort: Range, context: vscode.InlineValueContext, token: CancellationToken): ProviderResult<vscode.InlineValue[]>
     {
-		var params: TextDocumentPositionParams = {
-			position: context.stoppedLocation.start,
-			textDocument: { uri: document.uri.toString() }
-		};
+        var params: TextDocumentPositionParams = {
+            position: context.stoppedLocation.start,
+            textDocument: { uri: document.uri.toString() }
+        };
 
-		return this.languageClient.sendRequest(ProvideInlineValuesRequest, params).then(
+        return this.languageClient.sendRequest(ProvideInlineValuesRequest, params).then(
             function (result: any[]) : Array<vscode.InlineValue>
             {
                 let values = new Array<vscode.InlineValue>();

--- a/extension/syntaxes/angelscript.tmLanguage.json
+++ b/extension/syntaxes/angelscript.tmLanguage.json
@@ -1,6 +1,6 @@
 {
-	"name": "angelscript",
-	"scopeName": "source.angelscript",
+    "name": "angelscript",
+    "scopeName": "source.angelscript",
     "patterns": [
         {
             "name": "keyword.declaration.angelscript",
@@ -27,9 +27,9 @@
             "match": "\\b(int|float|double|bool|int32|int64|int16|int8|uint32|uint64|uint16|uint8|float32|float64)\\b"
         },
         {
-			"match": "::",
-			"name": "punctuation.separator.namespace.access.angelscript"
-		},
+            "match": "::",
+            "name": "punctuation.separator.namespace.access.angelscript"
+        },
 
         {
             "name": "meta.unrealmacro.property.angelsript",
@@ -182,17 +182,17 @@
             ]
         },
 
-		{
-			"match": "\\b(asset) ([A-Za-z0-9_]+) (of) ([A-Za-z0-9_]+)\\b",
-			"captures": {
-				"1": {
-					"name": "keyword.statement.angelscript"
-				},
-				"3": {
-					"name": "keyword.statement.angelscript"
-				}
-			}
-		},
+        {
+            "match": "\\b(asset) ([A-Za-z0-9_]+) (of) ([A-Za-z0-9_]+)\\b",
+            "captures": {
+                "1": {
+                    "name": "keyword.statement.angelscript"
+                },
+                "3": {
+                    "name": "keyword.statement.angelscript"
+                }
+            }
+        },
 
         {
             "name": "meta.preprocessor.angelsript",
@@ -200,54 +200,54 @@
             "end": "(?=\\n)"
         },
 
-		{
-			"begin": "f\"",
-			"beginCaptures": {
-				"0": {
-					"name": "keyword.operator.quantifier.regexp"
-				}
-			},
-			"end": "\"",
-			"endCaptures": {
-				"0": {
-					"name": "keyword.operator.quantifier.regexp"
-				}
-			},
-			"name": "string.quoted.double.angelscript",
-			"patterns": [
-				{
-					"include": "#string_escaped_char"
-				},
-				{
-					"match": "{{",
-					"name": "string.quoted.double.angelscript"
-				},
-				{
-					"match": "}}",
-					"name": "string.quoted.double.angelscript"
-				},
-				{
-					"begin": "{",
-					"beginCaptures": {
-						"0": {
-							"name": "keyword.formatexpression.angelscript"
-						}
-					},
-					"patterns": [
-						{
-							"include": "source.angelscript"
-						}
-					],
-					"name": "meta.embedded.expression.angelscript",
-					"end": "=?\\s*(:(.?[=<>^])?[0-9dxXbconeEfFgG=,+-\\.^%#\\s]*)?(}|(?=\")|(?=\n))",
-					"endCaptures": {
-						"0": {
-							"name": "keyword.formatexpression.angelscript"
-						}
-					}
-				}
-			]
-		},
+        {
+            "begin": "f\"",
+            "beginCaptures": {
+                "0": {
+                    "name": "keyword.operator.quantifier.regexp"
+                }
+            },
+            "end": "\"",
+            "endCaptures": {
+                "0": {
+                    "name": "keyword.operator.quantifier.regexp"
+                }
+            },
+            "name": "string.quoted.double.angelscript",
+            "patterns": [
+                {
+                    "include": "#string_escaped_char"
+                },
+                {
+                    "match": "{{",
+                    "name": "string.quoted.double.angelscript"
+                },
+                {
+                    "match": "}}",
+                    "name": "string.quoted.double.angelscript"
+                },
+                {
+                    "begin": "{",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "keyword.formatexpression.angelscript"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "source.angelscript"
+                        }
+                    ],
+                    "name": "meta.embedded.expression.angelscript",
+                    "end": "=?\\s*(:(.?[=<>^])?[0-9dxXbconeEfFgG=,+-\\.^%#\\s]*)?(}|(?=\")|(?=\n))",
+                    "endCaptures": {
+                        "0": {
+                            "name": "keyword.formatexpression.angelscript"
+                        }
+                    }
+                }
+            ]
+        },
 
         {
             "include": "#comments"
@@ -264,23 +264,23 @@
     ],
     "repository": {
         "comments": {
-			"patterns": [
-				{
-					"name": "comment.block.angelscript",
-					"begin": "(\\/\\*)",
-					"beginCaptures": {
-						"1": {
-							"name": "punctuation.definition.comment.begin.angelscript"
-						}
-					},
-					"end": "(\\*\\/)",
-					"endCaptures": {
-						"1": {
-							"name": "punctuation.definition.comment.end.angelscript"
-						}
-					}
-				},
-				{
+            "patterns": [
+                {
+                    "name": "comment.block.angelscript",
+                    "begin": "(\\/\\*)",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.comment.begin.angelscript"
+                        }
+                    },
+                    "end": "(\\*\\/)",
+                    "endCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.comment.end.angelscript"
+                        }
+                    }
+                },
+                {
                     "name": "comment.line.double-slash.angelscript",
                     "begin": "(\\/\\/)",
                     "beginCaptures": {
@@ -293,274 +293,274 @@
                         {
                         }
                     ]
-				}
-			]
-		},
+                }
+            ]
+        },
         "numbers": {
-			"match": "(?<!\\w)\\.?\\d(?:(?:[0-9a-zA-Z_\\.]|')|(?<=[eEpP])[+-])*",
-			"captures": {
-				"0": {
-					"patterns": [
-						{
-							"begin": "(?=.)",
-							"end": "$",
-							"patterns": [
-								{
-									"match": "(\\G0[xX])([0-9a-fA-F](?:[0-9a-fA-F]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?:(?<=[0-9a-fA-F])\\.|\\.(?=[0-9a-fA-F])))([0-9a-fA-F](?:[0-9a-fA-F]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?<!')([pP])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?([lLfF](?!\\w))?$",
-									"captures": {
-										"1": {
-											"name": "keyword.other.unit.hexadecimal.angelscript"
-										},
-										"2": {
-											"name": "constant.numeric.hexadecimal.angelscript",
-											"patterns": [
-												{
-													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
-													"name": "punctuation.separator.constant.numeric"
-												}
-											]
-										},
-										"3": {
-											"name": "punctuation.separator.constant.numeric"
-										},
-										"4": {
-											"name": "constant.numeric.hexadecimal.angelscript"
-										},
-										"5": {
-											"name": "constant.numeric.hexadecimal.angelscript",
-											"patterns": [
-												{
-													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
-													"name": "punctuation.separator.constant.numeric"
-												}
-											]
-										},
-										"6": {
-											"name": "punctuation.separator.constant.numeric"
-										},
-										"8": {
-											"name": "keyword.other.unit.exponent.hexadecimal.angelscript"
-										},
-										"9": {
-											"name": "keyword.operator.plus.exponent.hexadecimal.angelscript"
-										},
-										"10": {
-											"name": "keyword.operator.minus.exponent.hexadecimal.angelscript"
-										},
-										"11": {
-											"name": "constant.numeric.exponent.hexadecimal.angelscript",
-											"patterns": [
-												{
-													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
-													"name": "punctuation.separator.constant.numeric"
-												}
-											]
-										},
-										"12": {
-											"name": "keyword.other.unit.suffix.floating-point.angelscript"
-										}
-									}
-								},
-								{
-									"match": "(\\G(?=[0-9.])(?!0[xXbB]))([0-9](?:[0-9]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?:(?<=[0-9])\\.|\\.(?=[0-9])))([0-9](?:[0-9]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?<!')([eE])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?([lLfF](?!\\w))?$",
-									"captures": {
-										"2": {
-											"name": "constant.numeric.decimal.angelscript",
-											"patterns": [
-												{
-													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
-													"name": "punctuation.separator.constant.numeric"
-												}
-											]
-										},
-										"3": {
-											"name": "punctuation.separator.constant.numeric"
-										},
-										"4": {
-											"name": "constant.numeric.decimal.point.angelscript"
-										},
-										"5": {
-											"name": "constant.numeric.decimal.angelscript",
-											"patterns": [
-												{
-													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
-													"name": "punctuation.separator.constant.numeric"
-												}
-											]
-										},
-										"6": {
-											"name": "punctuation.separator.constant.numeric"
-										},
-										"8": {
-											"name": "keyword.other.unit.exponent.decimal.angelscript"
-										},
-										"9": {
-											"name": "keyword.operator.plus.exponent.decimal.angelscript"
-										},
-										"10": {
-											"name": "keyword.operator.minus.exponent.decimal.angelscript"
-										},
-										"11": {
-											"name": "constant.numeric.exponent.decimal.angelscript",
-											"patterns": [
-												{
-													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
-													"name": "punctuation.separator.constant.numeric"
-												}
-											]
-										},
-										"12": {
-											"name": "keyword.other.unit.suffix.floating-point.angelscript"
-										}
-									}
-								},
-								{
-									"match": "(\\G0[bB])([01](?:[01]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?$",
-									"captures": {
-										"1": {
-											"name": "keyword.other.unit.binary.angelscript"
-										},
-										"2": {
-											"name": "constant.numeric.binary.angelscript",
-											"patterns": [
-												{
-													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
-													"name": "punctuation.separator.constant.numeric"
-												}
-											]
-										},
-										"3": {
-											"name": "punctuation.separator.constant.numeric"
-										},
-										"4": {
-											"name": "keyword.other.unit.suffix.integer.angelscript"
-										}
-									}
-								},
-								{
-									"match": "(\\G0[oO])((?:[0-7]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))+)((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?$",
-									"captures": {
-										"1": {
-											"name": "keyword.other.unit.octal.angelscript"
-										},
-										"2": {
-											"name": "constant.numeric.octal.angelscript",
-											"patterns": [
-												{
-													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
-													"name": "punctuation.separator.constant.numeric"
-												}
-											]
-										},
-										"3": {
-											"name": "punctuation.separator.constant.numeric"
-										},
-										"4": {
-											"name": "keyword.other.unit.suffix.integer.angelscript"
-										}
-									}
-								},
-								{
-									"match": "(\\G0[xX])([0-9a-fA-F](?:[0-9a-fA-F]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)((?<!')([pP])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?$",
-									"captures": {
-										"1": {
-											"name": "keyword.other.unit.hexadecimal.angelscript"
-										},
-										"2": {
-											"name": "constant.numeric.hexadecimal.angelscript",
-											"patterns": [
-												{
-													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
-													"name": "punctuation.separator.constant.numeric"
-												}
-											]
-										},
-										"3": {
-											"name": "punctuation.separator.constant.numeric"
-										},
-										"5": {
-											"name": "keyword.other.unit.exponent.hexadecimal.angelscript"
-										},
-										"6": {
-											"name": "keyword.operator.plus.exponent.hexadecimal.angelscript"
-										},
-										"7": {
-											"name": "keyword.operator.minus.exponent.hexadecimal.angelscript"
-										},
-										"8": {
-											"name": "constant.numeric.exponent.hexadecimal.angelscript",
-											"patterns": [
-												{
-													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
-													"name": "punctuation.separator.constant.numeric"
-												}
-											]
-										},
-										"9": {
-											"name": "keyword.other.unit.suffix.integer.angelscript"
-										}
-									}
-								},
-								{
-									"match": "(\\G(?=[0-9.])(?!0[xXbB]))([0-9](?:[0-9]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)((?<!')([eE])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?$",
-									"captures": {
-										"2": {
-											"name": "constant.numeric.decimal.angelscript",
-											"patterns": [
-												{
-													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
-													"name": "punctuation.separator.constant.numeric"
-												}
-											]
-										},
-										"3": {
-											"name": "punctuation.separator.constant.numeric"
-										},
-										"5": {
-											"name": "keyword.other.unit.exponent.decimal.angelscript"
-										},
-										"6": {
-											"name": "keyword.operator.plus.exponent.decimal.angelscript"
-										},
-										"7": {
-											"name": "keyword.operator.minus.exponent.decimal.angelscript"
-										},
-										"8": {
-											"name": "constant.numeric.exponent.decimal.angelscript",
-											"patterns": [
-												{
-													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
-													"name": "punctuation.separator.constant.numeric"
-												}
-											]
-										},
-										"9": {
-											"name": "keyword.other.unit.suffix.integer.angelscript"
-										}
-									}
-								},
-								{
-									"match": "(?:(?:[0-9a-zA-Z_\\.]|')|(?<=[eEpP])[+-])+",
+            "match": "(?<!\\w)\\.?\\d(?:(?:[0-9a-zA-Z_\\.]|')|(?<=[eEpP])[+-])*",
+            "captures": {
+                "0": {
+                    "patterns": [
+                        {
+                            "begin": "(?=.)",
+                            "end": "$",
+                            "patterns": [
+                                {
+                                    "match": "(\\G0[xX])([0-9a-fA-F](?:[0-9a-fA-F]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?:(?<=[0-9a-fA-F])\\.|\\.(?=[0-9a-fA-F])))([0-9a-fA-F](?:[0-9a-fA-F]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?<!')([pP])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?([lLfF](?!\\w))?$",
+                                    "captures": {
+                                        "1": {
+                                            "name": "keyword.other.unit.hexadecimal.angelscript"
+                                        },
+                                        "2": {
+                                            "name": "constant.numeric.hexadecimal.angelscript",
+                                            "patterns": [
+                                                {
+                                                    "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                                                    "name": "punctuation.separator.constant.numeric"
+                                                }
+                                            ]
+                                        },
+                                        "3": {
+                                            "name": "punctuation.separator.constant.numeric"
+                                        },
+                                        "4": {
+                                            "name": "constant.numeric.hexadecimal.angelscript"
+                                        },
+                                        "5": {
+                                            "name": "constant.numeric.hexadecimal.angelscript",
+                                            "patterns": [
+                                                {
+                                                    "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                                                    "name": "punctuation.separator.constant.numeric"
+                                                }
+                                            ]
+                                        },
+                                        "6": {
+                                            "name": "punctuation.separator.constant.numeric"
+                                        },
+                                        "8": {
+                                            "name": "keyword.other.unit.exponent.hexadecimal.angelscript"
+                                        },
+                                        "9": {
+                                            "name": "keyword.operator.plus.exponent.hexadecimal.angelscript"
+                                        },
+                                        "10": {
+                                            "name": "keyword.operator.minus.exponent.hexadecimal.angelscript"
+                                        },
+                                        "11": {
+                                            "name": "constant.numeric.exponent.hexadecimal.angelscript",
+                                            "patterns": [
+                                                {
+                                                    "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                                                    "name": "punctuation.separator.constant.numeric"
+                                                }
+                                            ]
+                                        },
+                                        "12": {
+                                            "name": "keyword.other.unit.suffix.floating-point.angelscript"
+                                        }
+                                    }
+                                },
+                                {
+                                    "match": "(\\G(?=[0-9.])(?!0[xXbB]))([0-9](?:[0-9]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?:(?<=[0-9])\\.|\\.(?=[0-9])))([0-9](?:[0-9]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?<!')([eE])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?([lLfF](?!\\w))?$",
+                                    "captures": {
+                                        "2": {
+                                            "name": "constant.numeric.decimal.angelscript",
+                                            "patterns": [
+                                                {
+                                                    "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                                                    "name": "punctuation.separator.constant.numeric"
+                                                }
+                                            ]
+                                        },
+                                        "3": {
+                                            "name": "punctuation.separator.constant.numeric"
+                                        },
+                                        "4": {
+                                            "name": "constant.numeric.decimal.point.angelscript"
+                                        },
+                                        "5": {
+                                            "name": "constant.numeric.decimal.angelscript",
+                                            "patterns": [
+                                                {
+                                                    "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                                                    "name": "punctuation.separator.constant.numeric"
+                                                }
+                                            ]
+                                        },
+                                        "6": {
+                                            "name": "punctuation.separator.constant.numeric"
+                                        },
+                                        "8": {
+                                            "name": "keyword.other.unit.exponent.decimal.angelscript"
+                                        },
+                                        "9": {
+                                            "name": "keyword.operator.plus.exponent.decimal.angelscript"
+                                        },
+                                        "10": {
+                                            "name": "keyword.operator.minus.exponent.decimal.angelscript"
+                                        },
+                                        "11": {
+                                            "name": "constant.numeric.exponent.decimal.angelscript",
+                                            "patterns": [
+                                                {
+                                                    "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                                                    "name": "punctuation.separator.constant.numeric"
+                                                }
+                                            ]
+                                        },
+                                        "12": {
+                                            "name": "keyword.other.unit.suffix.floating-point.angelscript"
+                                        }
+                                    }
+                                },
+                                {
+                                    "match": "(\\G0[bB])([01](?:[01]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?$",
+                                    "captures": {
+                                        "1": {
+                                            "name": "keyword.other.unit.binary.angelscript"
+                                        },
+                                        "2": {
+                                            "name": "constant.numeric.binary.angelscript",
+                                            "patterns": [
+                                                {
+                                                    "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                                                    "name": "punctuation.separator.constant.numeric"
+                                                }
+                                            ]
+                                        },
+                                        "3": {
+                                            "name": "punctuation.separator.constant.numeric"
+                                        },
+                                        "4": {
+                                            "name": "keyword.other.unit.suffix.integer.angelscript"
+                                        }
+                                    }
+                                },
+                                {
+                                    "match": "(\\G0[oO])((?:[0-7]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))+)((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?$",
+                                    "captures": {
+                                        "1": {
+                                            "name": "keyword.other.unit.octal.angelscript"
+                                        },
+                                        "2": {
+                                            "name": "constant.numeric.octal.angelscript",
+                                            "patterns": [
+                                                {
+                                                    "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                                                    "name": "punctuation.separator.constant.numeric"
+                                                }
+                                            ]
+                                        },
+                                        "3": {
+                                            "name": "punctuation.separator.constant.numeric"
+                                        },
+                                        "4": {
+                                            "name": "keyword.other.unit.suffix.integer.angelscript"
+                                        }
+                                    }
+                                },
+                                {
+                                    "match": "(\\G0[xX])([0-9a-fA-F](?:[0-9a-fA-F]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)((?<!')([pP])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?$",
+                                    "captures": {
+                                        "1": {
+                                            "name": "keyword.other.unit.hexadecimal.angelscript"
+                                        },
+                                        "2": {
+                                            "name": "constant.numeric.hexadecimal.angelscript",
+                                            "patterns": [
+                                                {
+                                                    "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                                                    "name": "punctuation.separator.constant.numeric"
+                                                }
+                                            ]
+                                        },
+                                        "3": {
+                                            "name": "punctuation.separator.constant.numeric"
+                                        },
+                                        "5": {
+                                            "name": "keyword.other.unit.exponent.hexadecimal.angelscript"
+                                        },
+                                        "6": {
+                                            "name": "keyword.operator.plus.exponent.hexadecimal.angelscript"
+                                        },
+                                        "7": {
+                                            "name": "keyword.operator.minus.exponent.hexadecimal.angelscript"
+                                        },
+                                        "8": {
+                                            "name": "constant.numeric.exponent.hexadecimal.angelscript",
+                                            "patterns": [
+                                                {
+                                                    "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                                                    "name": "punctuation.separator.constant.numeric"
+                                                }
+                                            ]
+                                        },
+                                        "9": {
+                                            "name": "keyword.other.unit.suffix.integer.angelscript"
+                                        }
+                                    }
+                                },
+                                {
+                                    "match": "(\\G(?=[0-9.])(?!0[xXbB]))([0-9](?:[0-9]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)((?<!')([eE])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?$",
+                                    "captures": {
+                                        "2": {
+                                            "name": "constant.numeric.decimal.angelscript",
+                                            "patterns": [
+                                                {
+                                                    "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                                                    "name": "punctuation.separator.constant.numeric"
+                                                }
+                                            ]
+                                        },
+                                        "3": {
+                                            "name": "punctuation.separator.constant.numeric"
+                                        },
+                                        "5": {
+                                            "name": "keyword.other.unit.exponent.decimal.angelscript"
+                                        },
+                                        "6": {
+                                            "name": "keyword.operator.plus.exponent.decimal.angelscript"
+                                        },
+                                        "7": {
+                                            "name": "keyword.operator.minus.exponent.decimal.angelscript"
+                                        },
+                                        "8": {
+                                            "name": "constant.numeric.exponent.decimal.angelscript",
+                                            "patterns": [
+                                                {
+                                                    "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                                                    "name": "punctuation.separator.constant.numeric"
+                                                }
+                                            ]
+                                        },
+                                        "9": {
+                                            "name": "keyword.other.unit.suffix.integer.angelscript"
+                                        }
+                                    }
+                                },
+                                {
+                                    "match": "(?:(?:[0-9a-zA-Z_\\.]|')|(?<=[eEpP])[+-])+",
                                     "name": "constant.numeric.decimal.angelscript"
-								}
-							]
-						}
-					]
-				}
-			}
-		},
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         "string_escaped_char": {
-			"patterns": [
-				{
-					"match": "(?x)\\\\ (\n\\\\\t\t\t |\n[abefnprtv'\"?]   |\n[0-3]\\d{,2}\t |\n[4-7]\\d?\t\t|\nx[a-fA-F0-9]{,2} |\nu[a-fA-F0-9]{,4} |\nU[a-fA-F0-9]{,8} )",
-					"name": "constant.character.escape.angelscript"
-				},
-				{
-					"match": "\\\\.",
-					"name": "invalid.illegal.unknown-escape.angelscript"
-				}
-			]
-		},
+            "patterns": [
+                {
+                    "match": "(?x)\\\\ (\n\\\\\t\t\t |\n[abefnprtv'\"?]   |\n[0-3]\\d{,2}\t |\n[4-7]\\d?\t\t|\nx[a-fA-F0-9]{,2} |\nu[a-fA-F0-9]{,4} |\nU[a-fA-F0-9]{,8} )",
+                    "name": "constant.character.escape.angelscript"
+                },
+                {
+                    "match": "\\\\.",
+                    "name": "invalid.illegal.unknown-escape.angelscript"
+                }
+            ]
+        },
         "line_continuation_character": {
             "patterns": [
                 {
@@ -574,120 +574,120 @@
             ]
         },
         "strings": {
-			"patterns": [
-				{
-					"begin": "\"",
-					"beginCaptures": {
-						"0": {
-							"name": "punctuation.definition.string.begin.angelscript"
-						}
-					},
-					"end": "\"",
-					"endCaptures": {
-						"0": {
-							"name": "punctuation.definition.string.end.angelscript"
-						}
-					},
-					"name": "string.quoted.double.angelscript",
-					"patterns": [
-						{
-							"include": "#string_escaped_char"
-						},
-						{
-							"include": "#line_continuation_character"
-						}
-					]
-				},
-				{
-					"begin": "'",
-					"beginCaptures": {
-						"0": {
-							"name": "punctuation.definition.string.begin.angelscript"
-						}
-					},
-					"end": "'",
-					"endCaptures": {
-						"0": {
-							"name": "punctuation.definition.string.end.angelscript"
-						}
-					},
-					"name": "string.quoted.single.angelscript",
-					"patterns": [
-						{
-							"include": "#string_escaped_char"
-						},
-						{
-							"include": "#line_continuation_character"
-						}
-					]
-				}
-			]
-		},
+            "patterns": [
+                {
+                    "begin": "\"",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.begin.angelscript"
+                        }
+                    },
+                    "end": "\"",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.end.angelscript"
+                        }
+                    },
+                    "name": "string.quoted.double.angelscript",
+                    "patterns": [
+                        {
+                            "include": "#string_escaped_char"
+                        },
+                        {
+                            "include": "#line_continuation_character"
+                        }
+                    ]
+                },
+                {
+                    "begin": "'",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.begin.angelscript"
+                        }
+                    },
+                    "end": "'",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.end.angelscript"
+                        }
+                    },
+                    "name": "string.quoted.single.angelscript",
+                    "patterns": [
+                        {
+                            "include": "#string_escaped_char"
+                        },
+                        {
+                            "include": "#line_continuation_character"
+                        }
+                    ]
+                }
+            ]
+        },
         "operators": {
-			"patterns": [
-				{
-					"match": "--",
-					"name": "keyword.operator.decrement.angelscript"
-				},
-				{
-					"match": "\\+\\+",
-					"name": "keyword.operator.increment.angelscript"
-				},
-				{
-					"match": "%=|\\+=|-=|\\*=|(?<!\\()/=",
-					"name": "keyword.operator.assignment.compound.angelscript"
-				},
-				{
-					"match": "&=|\\^=|<<=|>>=|\\|=",
-					"name": "keyword.operator.assignment.compound.bitwise.angelscript"
-				},
-				{
-					"match": "<<|>>",
-					"name": "keyword.operator.bitwise.shift.angelscript"
-				},
-				{
-					"match": "!=|<=|>=|==|<|>",
-					"name": "keyword.operator.comparison.angelscript"
-				},
-				{
-					"match": "&&|!|\\|\\|",
-					"name": "keyword.operator.logical.angelscript"
-				},
-				{
-					"match": "&|\\||\\^|~",
-					"name": "keyword.operator.angelscript"
-				},
-				{
-					"match": "=",
-					"name": "keyword.operator.assignment.angelscript"
-				},
-				{
-					"match": "%|\\*|/|-|\\+",
-					"name": "keyword.operator.angelscript"
-				},
-				{
-					"begin": "(\\?)",
-					"beginCaptures": {
-						"1": {
-							"name": "keyword.operator.ternary.angelscript"
-						}
-					},
-					"end": "(:)",
-					"endCaptures": {
-						"1": {
-							"name": "keyword.operator.ternary.angelscript"
-						}
-					},
-					"patterns": [
-						{
-							"include": "$base"
-						}
-					]
-				}
-			]
-		},
-		"macro_parens": {
-			"begin": "\\(",
+            "patterns": [
+                {
+                    "match": "--",
+                    "name": "keyword.operator.decrement.angelscript"
+                },
+                {
+                    "match": "\\+\\+",
+                    "name": "keyword.operator.increment.angelscript"
+                },
+                {
+                    "match": "%=|\\+=|-=|\\*=|(?<!\\()/=",
+                    "name": "keyword.operator.assignment.compound.angelscript"
+                },
+                {
+                    "match": "&=|\\^=|<<=|>>=|\\|=",
+                    "name": "keyword.operator.assignment.compound.bitwise.angelscript"
+                },
+                {
+                    "match": "<<|>>",
+                    "name": "keyword.operator.bitwise.shift.angelscript"
+                },
+                {
+                    "match": "!=|<=|>=|==|<|>",
+                    "name": "keyword.operator.comparison.angelscript"
+                },
+                {
+                    "match": "&&|!|\\|\\|",
+                    "name": "keyword.operator.logical.angelscript"
+                },
+                {
+                    "match": "&|\\||\\^|~",
+                    "name": "keyword.operator.angelscript"
+                },
+                {
+                    "match": "=",
+                    "name": "keyword.operator.assignment.angelscript"
+                },
+                {
+                    "match": "%|\\*|/|-|\\+",
+                    "name": "keyword.operator.angelscript"
+                },
+                {
+                    "begin": "(\\?)",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.operator.ternary.angelscript"
+                        }
+                    },
+                    "end": "(:)",
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.operator.ternary.angelscript"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "$base"
+                        }
+                    ]
+                }
+            ]
+        },
+        "macro_parens": {
+            "begin": "\\(",
             "end": "\\)",
             "patterns": [
                 {
@@ -697,6 +697,6 @@
                     "include": "#numbers"
                 }
             ]
-		}
+        }
     }
 }

--- a/extension/syntaxes/angelscript_snippet.tmLanguage.json
+++ b/extension/syntaxes/angelscript_snippet.tmLanguage.json
@@ -1,49 +1,49 @@
 {
-	"name": "angelscript_snippet",
-	"scopeName": "source.angelscript_snippet",
+    "name": "angelscript_snippet",
+    "scopeName": "source.angelscript_snippet",
     "patterns": [
-		{
-			"name": "support.type.component.angelscript",
-			"match": "\\bU[A-Za-z_0-9]*Component\\b"
-		},
-		{
-			"name": "support.type.struct.angelscript",
-			"match": "\\b(FVector|FVector2D|TArray|TMap|TSet|FRotator|FQuat|FString|FName|FText|FTransform|TPerPlayer|TSubclassOf|TInstigated|TSoftObjectPtr|TSoftClassPtr)\\b"
-		},
-		{
-			"name": "support.type.struct.angelscript",
-			"match": "\\bF[A-Z][A-Za-z0-9_]+\\b"
-		},
-		{
-			"name": "support.type.angelscript",
-			"match": "\\bU[A-Z][A-Za-z0-9_]+\\b"
-		},
-		{
-			"name": "support.type.angelscript",
-			"match": "\\bE[A-Z][A-Za-z0-9_]+\\b"
-		},
-		{
-			"name": "support.type.actor.angelscript",
-			"match": "\\bA[A-Z][A-Za-z0-9_]+\\b"
-		},
-		{
-			"match": "\\.([A-Za-z0-9_]+)\\(",
+        {
+            "name": "support.type.component.angelscript",
+            "match": "\\bU[A-Za-z_0-9]*Component\\b"
+        },
+        {
+            "name": "support.type.struct.angelscript",
+            "match": "\\b(FVector|FVector2D|TArray|TMap|TSet|FRotator|FQuat|FString|FName|FText|FTransform|TPerPlayer|TSubclassOf|TInstigated|TSoftObjectPtr|TSoftClassPtr)\\b"
+        },
+        {
+            "name": "support.type.struct.angelscript",
+            "match": "\\bF[A-Z][A-Za-z0-9_]+\\b"
+        },
+        {
+            "name": "support.type.angelscript",
+            "match": "\\bU[A-Z][A-Za-z0-9_]+\\b"
+        },
+        {
+            "name": "support.type.angelscript",
+            "match": "\\bE[A-Z][A-Za-z0-9_]+\\b"
+        },
+        {
+            "name": "support.type.actor.angelscript",
+            "match": "\\bA[A-Z][A-Za-z0-9_]+\\b"
+        },
+        {
+            "match": "\\.([A-Za-z0-9_]+)\\(",
             "captures": {
                 "1": {
                     "name": "entity.name.function.member.angelscript"
                 }
             }
-		},
-		{
-			"match": "\\b([A-Za-z0-9_]+)\\(",
+        },
+        {
+            "match": "\\b([A-Za-z0-9_]+)\\(",
             "captures": {
                 "1": {
                     "name": "entity.name.function.member.angelscript"
                 }
             }
-		},
-		{
-			"match": "([A-Za-z0-9_]+)?::([A-Za-z0-9_]+)\\(",
+        },
+        {
+            "match": "([A-Za-z0-9_]+)?::([A-Za-z0-9_]+)\\(",
             "captures": {
                 "1": {
                     "name": "support.type.angelscript"
@@ -52,17 +52,17 @@
                     "name": "entity.name.function.angelscript"
                 }
             }
-		},
-		{
-			"match": "\\.([A-Za-z0-9_]+)\\b",
+        },
+        {
+            "match": "\\.([A-Za-z0-9_]+)\\b",
             "captures": {
                 "1": {
                     "name": "variable.other.property.angelscript"
                 }
             }
-		},
-		{
-			"match": "([A-Za-z0-9_]+)?::([A-Za-z0-9_]+)\\b",
+        },
+        {
+            "match": "([A-Za-z0-9_]+)?::([A-Za-z0-9_]+)\\b",
             "captures": {
                 "1": {
                     "name": "support.type.angelscript"
@@ -71,7 +71,7 @@
                     "name": "variable.other.global.angelscript"
                 }
             }
-		},
+        },
         {
             "include": "source.angelscript"
         }

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -1,13 +1,13 @@
 {
-	"compilerOptions": {
-		"module": "commonjs",
-		"target": "es2020",
-		"lib": ["ES2020"],
-		"outDir": "out",
-		"rootDir": "src",
-		"sourceMap": true,
-		"strictNullChecks": false,
-	},
-	"include": ["src"],
-	"exclude": ["node_modules", ".vscode-test"]
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es2020",
+        "lib": ["ES2020"],
+        "outDir": "out",
+        "rootDir": "src",
+        "sourceMap": true,
+        "strictNullChecks": false,
+    },
+    "include": ["src"],
+    "exclude": ["node_modules", ".vscode-test"]
 }

--- a/language-server/package-lock.json
+++ b/language-server/package-lock.json
@@ -1,1035 +1,1035 @@
 {
-	"name": "lsp-sample-server",
-	"version": "1.0.0",
-	"lockfileVersion": 2,
-	"requires": true,
-	"packages": {
-		"": {
-			"name": "lsp-sample-server",
-			"version": "1.0.0",
-			"license": "MIT",
-			"dependencies": {
-				"@types/glob": "^7.1.3",
-				"@types/nearley": "^2.0.0",
-				"glob": "^7.1.3",
-				"moo": "^0.5.1",
-				"nearley": "^2.20.1",
-				"vscode-languageserver": "^8.0.1",
-				"vscode-languageserver-textdocument": "^1.0.1",
-				"vscode-uri": "^3.0.3"
-			},
-			"devDependencies": {
-				"@types/vscode": "^1.65.0",
-				"typescript": "^4.5.5",
-				"vscode-test": "^1.3.0"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/@tootallnate/once": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/@types/glob": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
-			"dependencies": {
-				"@types/minimatch": "*",
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@types/minimatch": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
-		},
-		"node_modules/@types/nearley": {
-			"version": "2.11.2",
-			"resolved": "https://registry.npmjs.org/@types/nearley/-/nearley-2.11.2.tgz",
-			"integrity": "sha512-jeyIDNBxxyWyEk6HemDC+t32b4fxthVsgWDxf88qD2WpX0QpOyY8JvA80AElPTBGRUsO0EKnr6OeVOjK3ZDdnA=="
-		},
-		"node_modules/@types/node": {
-			"version": "17.0.42",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.42.tgz",
-			"integrity": "sha512-Q5BPGyGKcvQgAMbsr7qEGN/kIPN6zZecYYABeTDBizOsau+2NMdSVTar9UQw21A2+JyA2KRNDYaYrPB0Rpk2oQ=="
-		},
-		"node_modules/@types/vscode": {
-			"version": "1.68.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.68.0.tgz",
-			"integrity": "sha512-duBwEK5ta/eBBMJMQ7ECMEsMvlE3XJdRGh3xoS1uOO4jl2Z4LPBl5vx8WvBP10ERAgDRmIt/FaSD4RHyBGbChw==",
-			"dev": true
-		},
-		"node_modules/agent-base": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-			"dev": true,
-			"dependencies": {
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6.0.0"
-			}
-		},
-		"node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-		},
-		"node_modules/big-integer": {
-			"version": "1.6.51",
-			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-			"integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.6"
-			}
-		},
-		"node_modules/binary": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-			"integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-			"dev": true,
-			"dependencies": {
-				"buffers": "~0.1.1",
-				"chainsaw": "~0.1.0"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/bluebird": {
-			"version": "3.4.7",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-			"integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
-			"dev": true
-		},
-		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/buffer-indexof-polyfill": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-			"integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"node_modules/buffers": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-			"integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.2.0"
-			}
-		},
-		"node_modules/chainsaw": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-			"integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-			"dev": true,
-			"dependencies": {
-				"traverse": ">=0.3.0 <0.4"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-		},
-		"node_modules/concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-		},
-		"node_modules/core-util-is": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-			"dev": true
-		},
-		"node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/discontinuous-range": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-			"integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
-		},
-		"node_modules/duplexer2": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-			"integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-			"dev": true,
-			"dependencies": {
-				"readable-stream": "^2.0.2"
-			}
-		},
-		"node_modules/fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-		},
-		"node_modules/fstream": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-			"dev": true,
-			"dependencies": {
-				"graceful-fs": "^4.1.2",
-				"inherits": "~2.0.0",
-				"mkdirp": ">=0.5 0",
-				"rimraf": "2"
-			},
-			"engines": {
-				"node": ">=0.6"
-			}
-		},
-		"node_modules/fstream/node_modules/rimraf": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-			"dev": true,
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			}
-		},
-		"node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/graceful-fs": {
-			"version": "4.2.10",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-			"dev": true
-		},
-		"node_modules/http-proxy-agent": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-			"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-			"dev": true,
-			"dependencies": {
-				"@tootallnate/once": "1",
-				"agent-base": "6",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/https-proxy-agent": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-			"dev": true,
-			"dependencies": {
-				"agent-base": "6",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-			"dependencies": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
-		"node_modules/inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-		},
-		"node_modules/isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true
-		},
-		"node_modules/listenercount": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-			"integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
-			"dev": true
-		},
-		"node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/minimist": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-			"dev": true
-		},
-		"node_modules/mkdirp": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-			"dev": true,
-			"dependencies": {
-				"minimist": "^1.2.6"
-			},
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			}
-		},
-		"node_modules/moo": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
-			"integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w=="
-		},
-		"node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
-		},
-		"node_modules/nearley": {
-			"version": "2.20.1",
-			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
-			"integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-			"dependencies": {
-				"commander": "^2.19.0",
-				"moo": "^0.5.0",
-				"railroad-diagrams": "^1.0.0",
-				"randexp": "0.4.6"
-			},
-			"bin": {
-				"nearley-railroad": "bin/nearley-railroad.js",
-				"nearley-test": "bin/nearley-test.js",
-				"nearley-unparse": "bin/nearley-unparse.js",
-				"nearleyc": "bin/nearleyc.js"
-			},
-			"funding": {
-				"type": "individual",
-				"url": "https://nearley.js.org/#give-to-nearley"
-			}
-		},
-		"node_modules/once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-			"dependencies": {
-				"wrappy": "1"
-			}
-		},
-		"node_modules/path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/process-nextick-args": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true
-		},
-		"node_modules/railroad-diagrams": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-			"integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="
-		},
-		"node_modules/randexp": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-			"dependencies": {
-				"discontinuous-range": "1.0.0",
-				"ret": "~0.1.10"
-			},
-			"engines": {
-				"node": ">=0.12"
-			}
-		},
-		"node_modules/readable-stream": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"dev": true,
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/ret": {
-			"version": "0.1.15",
-			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-			"engines": {
-				"node": ">=0.12"
-			}
-		},
-		"node_modules/rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"dev": true,
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"node_modules/setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-			"dev": true
-		},
-		"node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
-		"node_modules/traverse": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-			"integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/typescript": {
-			"version": "4.7.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
-			"integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
-			"dev": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=4.2.0"
-			}
-		},
-		"node_modules/unzipper": {
-			"version": "0.10.11",
-			"resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-			"integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
-			"dev": true,
-			"dependencies": {
-				"big-integer": "^1.6.17",
-				"binary": "~0.3.0",
-				"bluebird": "~3.4.1",
-				"buffer-indexof-polyfill": "~1.0.0",
-				"duplexer2": "~0.1.4",
-				"fstream": "^1.0.12",
-				"graceful-fs": "^4.2.2",
-				"listenercount": "~1.0.1",
-				"readable-stream": "~2.3.6",
-				"setimmediate": "~1.0.4"
-			}
-		},
-		"node_modules/util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true
-		},
-		"node_modules/vscode-jsonrpc": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz",
-			"integrity": "sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ==",
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/vscode-languageserver": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.1.tgz",
-			"integrity": "sha512-sn7SjBwWm3OlmLtgg7jbM0wBULppyL60rj8K5HF0ny/MzN+GzPBX1kCvYdybhl7UW63V5V5tRVnyB8iwC73lSQ==",
-			"dependencies": {
-				"vscode-languageserver-protocol": "3.17.1"
-			},
-			"bin": {
-				"installServerIntoExtension": "bin/installServerIntoExtension"
-			}
-		},
-		"node_modules/vscode-languageserver-protocol": {
-			"version": "3.17.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz",
-			"integrity": "sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==",
-			"dependencies": {
-				"vscode-jsonrpc": "8.0.1",
-				"vscode-languageserver-types": "3.17.1"
-			}
-		},
-		"node_modules/vscode-languageserver-textdocument": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.5.tgz",
-			"integrity": "sha512-1ah7zyQjKBudnMiHbZmxz5bYNM9KKZYz+5VQLj+yr8l+9w3g+WAhCkUkWbhMEdC5u0ub4Ndiye/fDyS8ghIKQg=="
-		},
-		"node_modules/vscode-languageserver-types": {
-			"version": "3.17.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz",
-			"integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ=="
-		},
-		"node_modules/vscode-test": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-			"integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
-			"deprecated": "This package has been renamed to @vscode/test-electron, please update to the new name",
-			"dev": true,
-			"dependencies": {
-				"http-proxy-agent": "^4.0.1",
-				"https-proxy-agent": "^5.0.0",
-				"rimraf": "^3.0.2",
-				"unzipper": "^0.10.11"
-			},
-			"engines": {
-				"node": ">=8.9.3"
-			}
-		},
-		"node_modules/vscode-uri": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.3.tgz",
-			"integrity": "sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA=="
-		},
-		"node_modules/wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-		}
-	},
-	"dependencies": {
-		"@tootallnate/once": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-			"dev": true
-		},
-		"@types/glob": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
-			"requires": {
-				"@types/minimatch": "*",
-				"@types/node": "*"
-			}
-		},
-		"@types/minimatch": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
-		},
-		"@types/nearley": {
-			"version": "2.11.2",
-			"resolved": "https://registry.npmjs.org/@types/nearley/-/nearley-2.11.2.tgz",
-			"integrity": "sha512-jeyIDNBxxyWyEk6HemDC+t32b4fxthVsgWDxf88qD2WpX0QpOyY8JvA80AElPTBGRUsO0EKnr6OeVOjK3ZDdnA=="
-		},
-		"@types/node": {
-			"version": "17.0.42",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.42.tgz",
-			"integrity": "sha512-Q5BPGyGKcvQgAMbsr7qEGN/kIPN6zZecYYABeTDBizOsau+2NMdSVTar9UQw21A2+JyA2KRNDYaYrPB0Rpk2oQ=="
-		},
-		"@types/vscode": {
-			"version": "1.68.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.68.0.tgz",
-			"integrity": "sha512-duBwEK5ta/eBBMJMQ7ECMEsMvlE3XJdRGh3xoS1uOO4jl2Z4LPBl5vx8WvBP10ERAgDRmIt/FaSD4RHyBGbChw==",
-			"dev": true
-		},
-		"agent-base": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-			"dev": true,
-			"requires": {
-				"debug": "4"
-			}
-		},
-		"balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-		},
-		"big-integer": {
-			"version": "1.6.51",
-			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-			"integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-			"dev": true
-		},
-		"binary": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-			"integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-			"dev": true,
-			"requires": {
-				"buffers": "~0.1.1",
-				"chainsaw": "~0.1.0"
-			}
-		},
-		"bluebird": {
-			"version": "3.4.7",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-			"integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
-			"dev": true
-		},
-		"brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"requires": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"buffer-indexof-polyfill": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-			"integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-			"dev": true
-		},
-		"buffers": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-			"integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-			"dev": true
-		},
-		"chainsaw": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-			"integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-			"dev": true,
-			"requires": {
-				"traverse": ">=0.3.0 <0.4"
-			}
-		},
-		"commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-		},
-		"concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-		},
-		"core-util-is": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-			"dev": true
-		},
-		"debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"requires": {
-				"ms": "2.1.2"
-			}
-		},
-		"discontinuous-range": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-			"integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
-		},
-		"duplexer2": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-			"integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-			"dev": true,
-			"requires": {
-				"readable-stream": "^2.0.2"
-			}
-		},
-		"fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-		},
-		"fstream": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"inherits": "~2.0.0",
-				"mkdirp": ">=0.5 0",
-				"rimraf": "2"
-			},
-			"dependencies": {
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
-			}
-		},
-		"glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"requires": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			}
-		},
-		"graceful-fs": {
-			"version": "4.2.10",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-			"dev": true
-		},
-		"http-proxy-agent": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-			"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-			"dev": true,
-			"requires": {
-				"@tootallnate/once": "1",
-				"agent-base": "6",
-				"debug": "4"
-			}
-		},
-		"https-proxy-agent": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-			"dev": true,
-			"requires": {
-				"agent-base": "6",
-				"debug": "4"
-			}
-		},
-		"inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
-		"inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-		},
-		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true
-		},
-		"listenercount": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-			"integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
-			"dev": true
-		},
-		"minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"requires": {
-				"brace-expansion": "^1.1.7"
-			}
-		},
-		"minimist": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-			"dev": true
-		},
-		"mkdirp": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-			"dev": true,
-			"requires": {
-				"minimist": "^1.2.6"
-			}
-		},
-		"moo": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
-			"integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w=="
-		},
-		"ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
-		},
-		"nearley": {
-			"version": "2.20.1",
-			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
-			"integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-			"requires": {
-				"commander": "^2.19.0",
-				"moo": "^0.5.0",
-				"railroad-diagrams": "^1.0.0",
-				"randexp": "0.4.6"
-			}
-		},
-		"once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-			"requires": {
-				"wrappy": "1"
-			}
-		},
-		"path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
-		},
-		"process-nextick-args": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true
-		},
-		"railroad-diagrams": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-			"integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="
-		},
-		"randexp": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-			"requires": {
-				"discontinuous-range": "1.0.0",
-				"ret": "~0.1.10"
-			}
-		},
-		"readable-stream": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"dev": true,
-			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"ret": {
-			"version": "0.1.15",
-			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
-		},
-		"rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"dev": true,
-			"requires": {
-				"glob": "^7.1.3"
-			}
-		},
-		"safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-			"dev": true
-		},
-		"string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
-		"traverse": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-			"integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-			"dev": true
-		},
-		"typescript": {
-			"version": "4.7.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
-			"integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
-			"dev": true
-		},
-		"unzipper": {
-			"version": "0.10.11",
-			"resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-			"integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
-			"dev": true,
-			"requires": {
-				"big-integer": "^1.6.17",
-				"binary": "~0.3.0",
-				"bluebird": "~3.4.1",
-				"buffer-indexof-polyfill": "~1.0.0",
-				"duplexer2": "~0.1.4",
-				"fstream": "^1.0.12",
-				"graceful-fs": "^4.2.2",
-				"listenercount": "~1.0.1",
-				"readable-stream": "~2.3.6",
-				"setimmediate": "~1.0.4"
-			}
-		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true
-		},
-		"vscode-jsonrpc": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz",
-			"integrity": "sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ=="
-		},
-		"vscode-languageserver": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.1.tgz",
-			"integrity": "sha512-sn7SjBwWm3OlmLtgg7jbM0wBULppyL60rj8K5HF0ny/MzN+GzPBX1kCvYdybhl7UW63V5V5tRVnyB8iwC73lSQ==",
-			"requires": {
-				"vscode-languageserver-protocol": "3.17.1"
-			}
-		},
-		"vscode-languageserver-protocol": {
-			"version": "3.17.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz",
-			"integrity": "sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==",
-			"requires": {
-				"vscode-jsonrpc": "8.0.1",
-				"vscode-languageserver-types": "3.17.1"
-			}
-		},
-		"vscode-languageserver-textdocument": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.5.tgz",
-			"integrity": "sha512-1ah7zyQjKBudnMiHbZmxz5bYNM9KKZYz+5VQLj+yr8l+9w3g+WAhCkUkWbhMEdC5u0ub4Ndiye/fDyS8ghIKQg=="
-		},
-		"vscode-languageserver-types": {
-			"version": "3.17.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz",
-			"integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ=="
-		},
-		"vscode-test": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-			"integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
-			"dev": true,
-			"requires": {
-				"http-proxy-agent": "^4.0.1",
-				"https-proxy-agent": "^5.0.0",
-				"rimraf": "^3.0.2",
-				"unzipper": "^0.10.11"
-			}
-		},
-		"vscode-uri": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.3.tgz",
-			"integrity": "sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA=="
-		},
-		"wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-		}
-	}
+    "name": "lsp-sample-server",
+    "version": "1.0.0",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "lsp-sample-server",
+            "version": "1.0.0",
+            "license": "MIT",
+            "dependencies": {
+                "@types/glob": "^7.1.3",
+                "@types/nearley": "^2.0.0",
+                "glob": "^7.1.3",
+                "moo": "^0.5.1",
+                "nearley": "^2.20.1",
+                "vscode-languageserver": "^8.0.1",
+                "vscode-languageserver-textdocument": "^1.0.1",
+                "vscode-uri": "^3.0.3"
+            },
+            "devDependencies": {
+                "@types/vscode": "^1.65.0",
+                "typescript": "^4.5.5",
+                "vscode-test": "^1.3.0"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/@tootallnate/once": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/@types/glob": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+            "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+            "dependencies": {
+                "@types/minimatch": "*",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/minimatch": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+            "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
+        },
+        "node_modules/@types/nearley": {
+            "version": "2.11.2",
+            "resolved": "https://registry.npmjs.org/@types/nearley/-/nearley-2.11.2.tgz",
+            "integrity": "sha512-jeyIDNBxxyWyEk6HemDC+t32b4fxthVsgWDxf88qD2WpX0QpOyY8JvA80AElPTBGRUsO0EKnr6OeVOjK3ZDdnA=="
+        },
+        "node_modules/@types/node": {
+            "version": "17.0.42",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.42.tgz",
+            "integrity": "sha512-Q5BPGyGKcvQgAMbsr7qEGN/kIPN6zZecYYABeTDBizOsau+2NMdSVTar9UQw21A2+JyA2KRNDYaYrPB0Rpk2oQ=="
+        },
+        "node_modules/@types/vscode": {
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.68.0.tgz",
+            "integrity": "sha512-duBwEK5ta/eBBMJMQ7ECMEsMvlE3XJdRGh3xoS1uOO4jl2Z4LPBl5vx8WvBP10ERAgDRmIt/FaSD4RHyBGbChw==",
+            "dev": true
+        },
+        "node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+        },
+        "node_modules/big-integer": {
+            "version": "1.6.51",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/binary": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+            "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+            "dev": true,
+            "dependencies": {
+                "buffers": "~0.1.1",
+                "chainsaw": "~0.1.0"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/bluebird": {
+            "version": "3.4.7",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+            "dev": true
+        },
+        "node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/buffer-indexof-polyfill": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/buffers": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+            "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.2.0"
+            }
+        },
+        "node_modules/chainsaw": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+            "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+            "dev": true,
+            "dependencies": {
+                "traverse": ">=0.3.0 <0.4"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
+        "node_modules/concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+        },
+        "node_modules/core-util-is": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+            "dev": true
+        },
+        "node_modules/debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/discontinuous-range": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+            "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
+        },
+        "node_modules/duplexer2": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+            "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+            "dev": true,
+            "dependencies": {
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+        },
+        "node_modules/fstream": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+            "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
+            },
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/fstream/node_modules/rimraf": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+            "dev": true,
+            "dependencies": {
+                "glob": "^7.1.3"
+            },
+            "bin": {
+                "rimraf": "bin.js"
+            }
+        },
+        "node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.10",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "dev": true
+        },
+        "node_modules/http-proxy-agent": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+            "dev": true,
+            "dependencies": {
+                "@tootallnate/once": "1",
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+            "dependencies": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "dev": true
+        },
+        "node_modules/listenercount": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+            "dev": true
+        },
+        "node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/minimist": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+            "dev": true
+        },
+        "node_modules/mkdirp": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+            "dev": true,
+            "dependencies": {
+                "minimist": "^1.2.6"
+            },
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            }
+        },
+        "node_modules/moo": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
+            "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w=="
+        },
+        "node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
+        },
+        "node_modules/nearley": {
+            "version": "2.20.1",
+            "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+            "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+            "dependencies": {
+                "commander": "^2.19.0",
+                "moo": "^0.5.0",
+                "railroad-diagrams": "^1.0.0",
+                "randexp": "0.4.6"
+            },
+            "bin": {
+                "nearley-railroad": "bin/nearley-railroad.js",
+                "nearley-test": "bin/nearley-test.js",
+                "nearley-unparse": "bin/nearley-unparse.js",
+                "nearleyc": "bin/nearleyc.js"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://nearley.js.org/#give-to-nearley"
+            }
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true
+        },
+        "node_modules/railroad-diagrams": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+            "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="
+        },
+        "node_modules/randexp": {
+            "version": "0.4.6",
+            "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+            "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+            "dependencies": {
+                "discontinuous-range": "1.0.0",
+                "ret": "~0.1.10"
+            },
+            "engines": {
+                "node": ">=0.12"
+            }
+        },
+        "node_modules/readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dev": true,
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/ret": {
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+            "engines": {
+                "node": ">=0.12"
+            }
+        },
+        "node_modules/rimraf": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "dev": true,
+            "dependencies": {
+                "glob": "^7.1.3"
+            },
+            "bin": {
+                "rimraf": "bin.js"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
+        },
+        "node_modules/setimmediate": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+            "dev": true
+        },
+        "node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/traverse": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+            "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "4.7.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
+            "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
+        "node_modules/unzipper": {
+            "version": "0.10.11",
+            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
+            "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+            "dev": true,
+            "dependencies": {
+                "big-integer": "^1.6.17",
+                "binary": "~0.3.0",
+                "bluebird": "~3.4.1",
+                "buffer-indexof-polyfill": "~1.0.0",
+                "duplexer2": "~0.1.4",
+                "fstream": "^1.0.12",
+                "graceful-fs": "^4.2.2",
+                "listenercount": "~1.0.1",
+                "readable-stream": "~2.3.6",
+                "setimmediate": "~1.0.4"
+            }
+        },
+        "node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+            "dev": true
+        },
+        "node_modules/vscode-jsonrpc": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz",
+            "integrity": "sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ==",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/vscode-languageserver": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.1.tgz",
+            "integrity": "sha512-sn7SjBwWm3OlmLtgg7jbM0wBULppyL60rj8K5HF0ny/MzN+GzPBX1kCvYdybhl7UW63V5V5tRVnyB8iwC73lSQ==",
+            "dependencies": {
+                "vscode-languageserver-protocol": "3.17.1"
+            },
+            "bin": {
+                "installServerIntoExtension": "bin/installServerIntoExtension"
+            }
+        },
+        "node_modules/vscode-languageserver-protocol": {
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz",
+            "integrity": "sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==",
+            "dependencies": {
+                "vscode-jsonrpc": "8.0.1",
+                "vscode-languageserver-types": "3.17.1"
+            }
+        },
+        "node_modules/vscode-languageserver-textdocument": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.5.tgz",
+            "integrity": "sha512-1ah7zyQjKBudnMiHbZmxz5bYNM9KKZYz+5VQLj+yr8l+9w3g+WAhCkUkWbhMEdC5u0ub4Ndiye/fDyS8ghIKQg=="
+        },
+        "node_modules/vscode-languageserver-types": {
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz",
+            "integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ=="
+        },
+        "node_modules/vscode-test": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
+            "integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
+            "deprecated": "This package has been renamed to @vscode/test-electron, please update to the new name",
+            "dev": true,
+            "dependencies": {
+                "http-proxy-agent": "^4.0.1",
+                "https-proxy-agent": "^5.0.0",
+                "rimraf": "^3.0.2",
+                "unzipper": "^0.10.11"
+            },
+            "engines": {
+                "node": ">=8.9.3"
+            }
+        },
+        "node_modules/vscode-uri": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.3.tgz",
+            "integrity": "sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA=="
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+        }
+    },
+    "dependencies": {
+        "@tootallnate/once": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+            "dev": true
+        },
+        "@types/glob": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+            "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+            "requires": {
+                "@types/minimatch": "*",
+                "@types/node": "*"
+            }
+        },
+        "@types/minimatch": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+            "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
+        },
+        "@types/nearley": {
+            "version": "2.11.2",
+            "resolved": "https://registry.npmjs.org/@types/nearley/-/nearley-2.11.2.tgz",
+            "integrity": "sha512-jeyIDNBxxyWyEk6HemDC+t32b4fxthVsgWDxf88qD2WpX0QpOyY8JvA80AElPTBGRUsO0EKnr6OeVOjK3ZDdnA=="
+        },
+        "@types/node": {
+            "version": "17.0.42",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.42.tgz",
+            "integrity": "sha512-Q5BPGyGKcvQgAMbsr7qEGN/kIPN6zZecYYABeTDBizOsau+2NMdSVTar9UQw21A2+JyA2KRNDYaYrPB0Rpk2oQ=="
+        },
+        "@types/vscode": {
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.68.0.tgz",
+            "integrity": "sha512-duBwEK5ta/eBBMJMQ7ECMEsMvlE3XJdRGh3xoS1uOO4jl2Z4LPBl5vx8WvBP10ERAgDRmIt/FaSD4RHyBGbChw==",
+            "dev": true
+        },
+        "agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
+            "requires": {
+                "debug": "4"
+            }
+        },
+        "balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+        },
+        "big-integer": {
+            "version": "1.6.51",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+            "dev": true
+        },
+        "binary": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+            "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+            "dev": true,
+            "requires": {
+                "buffers": "~0.1.1",
+                "chainsaw": "~0.1.0"
+            }
+        },
+        "bluebird": {
+            "version": "3.4.7",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+            "dev": true
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "buffer-indexof-polyfill": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+            "dev": true
+        },
+        "buffers": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+            "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+            "dev": true
+        },
+        "chainsaw": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+            "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+            "dev": true,
+            "requires": {
+                "traverse": ">=0.3.0 <0.4"
+            }
+        },
+        "commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+        },
+        "core-util-is": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+            "dev": true
+        },
+        "debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dev": true,
+            "requires": {
+                "ms": "2.1.2"
+            }
+        },
+        "discontinuous-range": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+            "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
+        },
+        "duplexer2": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+            "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+        },
+        "fstream": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+            "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
+            },
+            "dependencies": {
+                "rimraf": {
+                    "version": "2.7.1",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+                    "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                }
+            }
+        },
+        "glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "graceful-fs": {
+            "version": "4.2.10",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "dev": true
+        },
+        "http-proxy-agent": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+            "dev": true,
+            "requires": {
+                "@tootallnate/once": "1",
+                "agent-base": "6",
+                "debug": "4"
+            }
+        },
+        "https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
+            "requires": {
+                "agent-base": "6",
+                "debug": "4"
+            }
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "dev": true
+        },
+        "listenercount": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.2.6"
+            }
+        },
+        "moo": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
+            "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w=="
+        },
+        "ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
+        },
+        "nearley": {
+            "version": "2.20.1",
+            "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+            "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+            "requires": {
+                "commander": "^2.19.0",
+                "moo": "^0.5.0",
+                "railroad-diagrams": "^1.0.0",
+                "randexp": "0.4.6"
+            }
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
+        },
+        "process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true
+        },
+        "railroad-diagrams": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+            "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="
+        },
+        "randexp": {
+            "version": "0.4.6",
+            "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+            "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+            "requires": {
+                "discontinuous-range": "1.0.0",
+                "ret": "~0.1.10"
+            }
+        },
+        "readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dev": true,
+            "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "ret": {
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+        },
+        "rimraf": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
+        },
+        "setimmediate": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+            "dev": true
+        },
+        "string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "traverse": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+            "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+            "dev": true
+        },
+        "typescript": {
+            "version": "4.7.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
+            "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
+            "dev": true
+        },
+        "unzipper": {
+            "version": "0.10.11",
+            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
+            "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+            "dev": true,
+            "requires": {
+                "big-integer": "^1.6.17",
+                "binary": "~0.3.0",
+                "bluebird": "~3.4.1",
+                "buffer-indexof-polyfill": "~1.0.0",
+                "duplexer2": "~0.1.4",
+                "fstream": "^1.0.12",
+                "graceful-fs": "^4.2.2",
+                "listenercount": "~1.0.1",
+                "readable-stream": "~2.3.6",
+                "setimmediate": "~1.0.4"
+            }
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+            "dev": true
+        },
+        "vscode-jsonrpc": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz",
+            "integrity": "sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ=="
+        },
+        "vscode-languageserver": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.1.tgz",
+            "integrity": "sha512-sn7SjBwWm3OlmLtgg7jbM0wBULppyL60rj8K5HF0ny/MzN+GzPBX1kCvYdybhl7UW63V5V5tRVnyB8iwC73lSQ==",
+            "requires": {
+                "vscode-languageserver-protocol": "3.17.1"
+            }
+        },
+        "vscode-languageserver-protocol": {
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz",
+            "integrity": "sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==",
+            "requires": {
+                "vscode-jsonrpc": "8.0.1",
+                "vscode-languageserver-types": "3.17.1"
+            }
+        },
+        "vscode-languageserver-textdocument": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.5.tgz",
+            "integrity": "sha512-1ah7zyQjKBudnMiHbZmxz5bYNM9KKZYz+5VQLj+yr8l+9w3g+WAhCkUkWbhMEdC5u0ub4Ndiye/fDyS8ghIKQg=="
+        },
+        "vscode-languageserver-types": {
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz",
+            "integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ=="
+        },
+        "vscode-test": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
+            "integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
+            "dev": true,
+            "requires": {
+                "http-proxy-agent": "^4.0.1",
+                "https-proxy-agent": "^5.0.0",
+                "rimraf": "^3.0.2",
+                "unzipper": "^0.10.11"
+            }
+        },
+        "vscode-uri": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.3.tgz",
+            "integrity": "sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA=="
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+        }
+    }
 }

--- a/language-server/package.json
+++ b/language-server/package.json
@@ -1,30 +1,30 @@
 {
-	"name": "lsp-sample-server",
-	"description": "Example implementation of a language server in node.",
-	"version": "1.0.0",
-	"author": "Microsoft Corporation",
-	"license": "MIT",
-	"engines": {
-		"node": "*"
-	},
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/Microsoft/vscode-extension-samples"
-	},
-	"dependencies": {
-		"@types/glob": "^7.1.3",
-		"@types/nearley": "^2.0.0",
-		"glob": "^7.1.3",
-		"moo": "^0.5.1",
-		"nearley": "^2.20.1",
-		"vscode-languageserver": "^8.0.1",
-		"vscode-languageserver-textdocument": "^1.0.1",
-		"vscode-uri": "^3.0.3"
-	},
-	"devDependencies": {
-		"@types/vscode": "^1.65.0",
-		"typescript": "^4.5.5",
-		"vscode-test": "^1.3.0"
-	},
-	"scripts": {}
+    "name": "lsp-sample-server",
+    "description": "Example implementation of a language server in node.",
+    "version": "1.0.0",
+    "author": "Microsoft Corporation",
+    "license": "MIT",
+    "engines": {
+        "node": "*"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Microsoft/vscode-extension-samples"
+    },
+    "dependencies": {
+        "@types/glob": "^7.1.3",
+        "@types/nearley": "^2.0.0",
+        "glob": "^7.1.3",
+        "moo": "^0.5.1",
+        "nearley": "^2.20.1",
+        "vscode-languageserver": "^8.0.1",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-uri": "^3.0.3"
+    },
+    "devDependencies": {
+        "@types/vscode": "^1.65.0",
+        "typescript": "^4.5.5",
+        "vscode-test": "^1.3.0"
+    },
+    "scripts": {}
 }

--- a/language-server/src/as_parser.ts
+++ b/language-server/src/as_parser.ts
@@ -247,7 +247,7 @@ export class ASModule
 
         return null;
     }
-    
+
     isModuleImported(modulename : string) : boolean
     {
         return this.flatImportList.has(modulename);
@@ -586,7 +586,7 @@ export class ASScope extends ASElement
         {
             return null;
         }
-        
+
     }
 
     getNamespace() : typedb.DBNamespace
@@ -1124,7 +1124,7 @@ export function UpdateModuleFromContentChanges(module : ASModule, contentChanges
         {
             if (change.text.length == 0)
             {
-                // Deletes also dirty the character before them 
+                // Deletes also dirty the character before them
                 module.lastEditStart = textDocument.offsetAt(change.range.start) - 1;
                 module.lastEditEnd = textDocument.offsetAt(change.range.start) + change.text.length;
             }
@@ -1988,7 +1988,7 @@ function GenerateTypeInformation(scope : ASScope)
         else if (scope.previous.ast.type == node_types.EnumDefinition)
         {
             scope.declaration = scope.previous;
-            
+
             let enumdef = scope.previous.ast;
             let dbtype = AddDBType(scope, enumdef.name.value);
             dbtype.isEnum = true;
@@ -2271,7 +2271,7 @@ function GenerateTypeInformation(scope : ASScope)
                         dbtype.isEvent = true;
                     else
                         dbtype.isDelegate = true;
-                    
+
                     if (statement.ast.documentation)
                         dbtype.documentation = typedb.FormatDocumentationComment(statement.ast.documentation);
                     dbtype.moduleOffset = statement.start_offset + signature.name.start;
@@ -2368,7 +2368,7 @@ function GenerateTypeInformation(scope : ASScope)
     {
         let namespace = scope.getNamespace();
         let hasDefaultConstructor = false;
-        
+
         let constructors = namespace.findSymbols(scope.dbtype.name);
         for (let constr of constructors)
         {
@@ -4010,7 +4010,7 @@ function DetectNodeSymbols(scope : ASScope, statement : ASStatement, node : any,
                         break;
                     }
                 }
-                
+
                 // Find the actual namespace we're looking in
                 let qualifiedNamespace = "";
                 for (let i = 0, count = identifierNodes.length - 1; i < count; ++i)
@@ -4592,7 +4592,7 @@ function DetectNodeSymbols(scope : ASScope, statement : ASStatement, node : any,
         // access X = private, Y, Z (mod);
         case node_types.AccessDeclaration:
         {
-            // Add symbol for the name 
+            // Add symbol for the name
             if (node.name)
             {
                 let insideType = scope.dbtype ? scope.dbtype.name : null;
@@ -4963,7 +4963,7 @@ function DetectIdentifierSymbols(scope : ASScope, statement : ASStatement, node 
                 return null;
         }
     }
-    
+
     // We might be typing a typename at the start of a declaration, which accidentally got parsed as an identifier due to incompleteness
     let isTypingSingleIdentifier = (node == statement.ast && scope.module.isEditingInside(statement.start_offset + node.start, statement.end_offset + node.end + 2));
     if (isTypingSingleIdentifier)
@@ -5048,7 +5048,7 @@ function DetectSymbolFromNamespacedIdentifier(scope : ASScope, statement : ASSta
         end: identifier.start+nsName.length,
         value: nsName
     }, ASSymbolType.Namespace, null, null);
-    
+
     if (refType && (namespace || refType.isEnum))
     {
         nsSymbol.type = ASSymbolType.Typename;
@@ -5605,7 +5605,7 @@ function DetectFormatStringSymbols(scope : ASScope, statement : ASStatement, nod
                 expressions[i] = match[1];
             }
         }
-    
+
         let fakeStatement = new ASStatement();
         fakeStatement.content = expressions[i];
         fakeStatement.start_offset = statement.start_offset + node.start + offsets[i];

--- a/language-server/src/code_actions.ts
+++ b/language-server/src/code_actions.ts
@@ -84,7 +84,7 @@ export function GetCodeActions(asmodule : scriptfiles.ASModule, range : Range, d
 
     // Actions for switch blocks
     AddSwitchCaseActions(context);
-    
+
     // Actions to generate a method by usage
     AddGenerateMethodActions(context);
 
@@ -629,7 +629,7 @@ function AddCastHelpers(context : CodeActionContext)
     // Maybe we can implicitly convert
     if (rightType.inheritsFrom(leftType.name))
         return;
-    
+
     // Cast needs to make sense
     if (!leftType.inheritsFrom(rightType.name))
         return;
@@ -1295,7 +1295,7 @@ function AddSwitchCaseActions(context : CodeActionContext)
         }
         else if (caseStatement.ast.type != scriptfiles.node_types.CaseStatement)
             continue;
-        
+
         let labelNode = caseStatement.ast.children[0];
         if (!labelNode || labelNode.type != scriptfiles.node_types.NamespaceAccess)
             continue;
@@ -1390,7 +1390,7 @@ function ResolveInsertCases(asmodule : scriptfiles.ASModule, action : CodeAction
     let insertString = "";
     let cases : Array<string> = data.cases;
     for (let label of cases)
-        insertString += `${indent}case ${label}:\n${indent}break;\n`; 
+        insertString += `${indent}case ${label}:\n${indent}break;\n`;
 
     let insertPosition : Position = null;
     if (data.defaultCasePosition != -1)
@@ -1578,7 +1578,7 @@ function AddGenerateMethodActions(context : CodeActionContext)
 
                 args += argTypename;
                 args += " ";
-                
+
                 let argName = FindUsableIdentifierInExpression(argNode);
                 if (argName)
                 {

--- a/language-server/src/code_lenses.ts
+++ b/language-server/src/code_lenses.ts
@@ -105,11 +105,11 @@ function AddAssetImplementationsLense(scope : scriptfiles.ASScope, dbtype : type
     let lensLine = Math.max(startPos.line, 0);
 
     lenses.push(<CodeLens> {
-		range: Range.create(Position.create(lensLine, 0), Position.create(lensLine, 10000)),
-		command: <Command> {
-			title: message,
-			command: "angelscript.openAssets",
+        range: Range.create(Position.create(lensLine, 0), Position.create(lensLine, 10000)),
+        command: <Command> {
+            title: message,
+            command: "angelscript.openAssets",
             arguments: [dbtype.name],
-		}
+        }
     });
 }

--- a/language-server/src/inlay_hints.ts
+++ b/language-server/src/inlay_hints.ts
@@ -407,7 +407,7 @@ export function GetInlayHintsForNode(scope : scriptfiles.ASScope, statement : sc
 
                         if (paramIndex >= func.args.length)
                             continue;
-                        
+
                         let isFallback = func.args.length < argCount;
                         if (dbParam && dbParam.name != func.args[paramIndex].name && (!isFallback || paramIsFallback))
                             paramNameAmbiguous = true;

--- a/language-server/src/inline_values.ts
+++ b/language-server/src/inline_values.ts
@@ -123,7 +123,7 @@ function AddThisObjectInlineValue(context : InlineValueContext, scope : scriptfi
                 startPos.line = statementStart.line+1;
 
             startPos.character = 4;
-            
+
             range = Range.create(startPos, startPos);
         }
         else

--- a/language-server/src/ls_diagnostics.ts
+++ b/language-server/src/ls_diagnostics.ts
@@ -74,7 +74,7 @@ export function UpdateScriptModuleDiagnostics(asmodule : scriptfiles.ASModule, i
     let diagnostics = new Array<Diagnostic>();
     if (!asmodule.rootscope)
         return;
-    
+
     // Go through all the parsed scopes and add diagnostics
     AddScopeDiagnostics(asmodule.rootscope, diagnostics);
 
@@ -181,7 +181,7 @@ function VerifyDelegateBinds(asmodule : scriptfiles.ASModule, diagnostics : Arra
         let objType = scriptfiles.ResolveTypeFromExpression(delegateBind.scope, delegateBind.node_object);
         if (!objType)
             continue;
-        
+
         let foundFunc = objType.findFirstSymbol(funcName, typedb.DBAllowSymbol.Functions);
         if (!foundFunc || !(foundFunc instanceof typedb.DBMethod))
         {
@@ -322,7 +322,7 @@ function TrimDiagnosticPositions(asmodule : scriptfiles.ASModule, diagnostics : 
                 {
                     offset += 1;
                 }
-                else 
+                else
                 {
                     if (char != '\n' && char != '\r')
                         diag.range.start = asmodule.getPosition(offset);

--- a/language-server/src/parsed_completion.ts
+++ b/language-server/src/parsed_completion.ts
@@ -125,7 +125,7 @@ class CompletionContext
             return false;
         if (this.expectedType.name == typename)
             return true;
-           
+
         let dbtype = typedb.GetTypeByName(typename);
         if (!dbtype)
             return false;
@@ -465,7 +465,7 @@ export function SortMethodsBasedOnArgumentTypes(methods: Array<typedb.DBMethod>,
 {
     let context = GenerateCompletionContext(asmodule, offset - 1);
     let argContext = GenerateCompletionArguments(context);
-    
+
     let scoredFunctions = new Array<[typedb.DBMethod, number]>();
 
     for (let func of methods)
@@ -618,7 +618,7 @@ function AddCompletionsFromCallSignature(context: CompletionContext, completions
             let argumentIndex = context.subOuterArgumentIndex;
             if (activeMethod.isMixin)
                 argumentIndex += 1;
-            
+
             if (argumentIndex < activeMethod.args.length)
             {
                 let arg = activeMethod.args[argumentIndex];
@@ -702,7 +702,7 @@ function AddCompletionsFromImportStatement(context : CompletionContext, completi
         let complString = "";
         if(context.completingSymbol)
             complString = context.completingSymbol;
-        
+
         let untilDot = "";
         let dotPos = complString.lastIndexOf(".");
         if (dotPos != -1)
@@ -750,7 +750,7 @@ function AddCompletionsFromUnrealMacro(context : CompletionContext, completions 
                         context.baseStatement.ast.macro.end);
                 }
             }
-            
+
             // Detect if we're inside a sub-specifier
             let isPropertySpec = false;
             if (/[\r\n\s]*UPROPERTY\s*\(.*\)[\r\n\s]*$/.test(context.baseStatement.content))
@@ -910,7 +910,7 @@ function AddCompletionsFromKeywords(context : CompletionContext, completions : A
             ], completions);
         }
     }
-    
+
     if (!context.isRightExpression && !context.isSubExpression)
     {
         AddCompletionsFromKeywordList(context, [
@@ -1289,7 +1289,7 @@ export function AddCompletionsFromType(context : CompletionContext, curtype : ty
                         props.add(propname);
                     }
                 }
-                
+
                 if (func.name.startsWith("Set"))
                 {
                     let propname = func.name.substring(3);
@@ -1403,7 +1403,7 @@ export function AddCompletionsFromType(context : CompletionContext, curtype : ty
                     if (!typedb.IsPrimitive(func.returnType))
                         compl.commitCharacters.push(".");
                 }
-                
+
                 completions.push(compl);
             }
         }
@@ -2443,7 +2443,7 @@ function ExtractPriorExpressionAndSymbol(context : CompletionContext, node : any
             }
             else
             {
-                // We have to pull apart the namespace access a bit 
+                // We have to pull apart the namespace access a bit
                 if (node.has_statement && node.children[0] && node.children[0].type == scriptfiles.node_types.NamespaceAccess)
                 {
                     let nsNode = node.children[0];
@@ -2457,7 +2457,7 @@ function ExtractPriorExpressionAndSymbol(context : CompletionContext, node : any
                         let typeName = nsNode.children[0].value;
                         if (nsNode.children[1].value)
                             typeName += "::"+nsNode.children[1].value;
-                        
+
                         context.priorType = typedb.LookupType(context.scope.getNamespace(), typeName);
                         context.priorTypeWasNamespace = true;
                         context.requiresPriorType = true;
@@ -3276,7 +3276,7 @@ function isPropertyAccessibleFromScope(curtype : typedb.DBType | typedb.DBNamesp
         if (!isEditScope(inScope))
             return false;
     }
-    
+
     if (prop.isNoEdit)
     {
         if (isEditScope(inScope))
@@ -3354,7 +3354,7 @@ function GetCodeOffsetIgnoreTable(code : string) : Array<number>
     let sq_string = false;
     let dq_string = false;
     let escape_sequence = false;
-    
+
     let inFormatString = false;
     let inFormatExpression = false;
 
@@ -3853,7 +3853,7 @@ export function Resolve(item : CompletionItem) : CompletionItem
             doc = setFunc.findAvailableDocumentation();
         if (doc)
             docStr += "\n"+doc.replace(/\n/g,"\n\n")+"\n\n";
-            
+
         item.documentation = <MarkupContent> {
             kind: MarkupKind.Markdown,
             value: docStr,

--- a/language-server/src/server.ts
+++ b/language-server/src/server.ts
@@ -254,10 +254,10 @@ connection.onInitialize((_params): InitializeResult => {
             RootUris.push(decodeURIComponent(Workspace.uri));
         }
     }
-    
-    
+
+
     connection.console.log("Workspace roots: " + Roots);
-    
+
     //connection.console.log("RootPath: "+RootPath);
     //connection.console.log("RootUri: "+RootUri+" from "+_params.rootUri);
 
@@ -458,7 +458,7 @@ function ReResolveAllModules()
 {
     if (IsServicingQueues)
         return;
-    
+
     scriptfiles.ClearAllResolvedModules();
 
     // Update diagnostics on all modules
@@ -841,7 +841,7 @@ function getModuleName(uri : string) : string
     for (let rootUri of RootUris) {
         if (modulename.startsWith(rootUri)) {
             modulename = modulename.replace(rootUri, "");
-            break;            
+            break;
         }
     }
     modulename = modulename.replace(".as", "");
@@ -908,8 +908,8 @@ connection.onRequest("angelscript/provideInlineValues", (...params: any[]) : any
         return null;
     return inlinevalues.ProvideInlineValues(asmodule, pos.position);
 });
-    
- connection.onDidChangeTextDocument((params) => {
+
+connection.onDidChangeTextDocument((params) => {
     // The content of a text document did change in VSCode.
     // params.uri uniquely identifies the document.
     // params.contentChanges describe the content changes to the document.
@@ -918,7 +918,7 @@ connection.onRequest("angelscript/provideInlineValues", (...params: any[]) : any
 
     let uri = params.textDocument.uri;
     let modulename = getModuleName(uri);
-    
+
     let asmodule = scriptfiles.GetOrCreateModule(modulename, getPathName(uri), uri);
     if (!asmodule.loaded)
         scriptfiles.UpdateModuleFromDisk(asmodule);
@@ -953,10 +953,10 @@ connection.onRequest("angelscript/provideInlineValues", (...params: any[]) : any
                 });
         }
     }
- });
+});
 
- connection.onDidOpenTextDocument(function (params : DidOpenTextDocumentParams)
- {
+connection.onDidOpenTextDocument(function (params : DidOpenTextDocumentParams)
+{
     let uri = params.textDocument.uri;
     let modulename = getModuleName(uri);
 
@@ -970,17 +970,17 @@ connection.onRequest("angelscript/provideInlineValues", (...params: any[]) : any
         scriptfiles.ResolveModule(asmodule);
         scriptdiagnostics.UpdateScriptModuleDiagnostics(asmodule);
     }
- });
+});
 
- connection.onDidCloseTextDocument(function (params : DidCloseTextDocumentParams)
- {
+connection.onDidCloseTextDocument(function (params : DidCloseTextDocumentParams)
+{
     let asmodule = scriptfiles.GetModuleByUri(params.textDocument.uri);
     if (asmodule)
         asmodule.isOpened = false;
- });
+});
 
- connection.onDidChangeConfiguration(function (change : DidChangeConfigurationParams)
- {
+connection.onDidChangeConfiguration(function (change : DidChangeConfigurationParams)
+{
     let settingsObject = change.settings as any;
     let settings : any = settingsObject.UnrealAngelscript;
     if (!settings)
@@ -1023,7 +1023,7 @@ connection.onRequest("angelscript/provideInlineValues", (...params: any[]) : any
     inlineValueSettings.showInlineValueForLocalVariables = settings.inlineValues.showInlineValueForLocalVariables;
     inlineValueSettings.showInlineValueForParameters = settings.inlineValues.showInlineValueForParameters;
     inlineValueSettings.showInlineValueForMemberAssignment = settings.inlineValues.showInlineValueForMemberAssignment;
- });
+});
 
 function TryResolveInlayHints(asmodule : scriptfiles.ASModule, range : Range) : Array<inlayhints.ASInlayHint> | null
 {

--- a/language-server/src/symbols.ts
+++ b/language-server/src/symbols.ts
@@ -171,7 +171,7 @@ export function GetSymbolDefinition(asmodule : scriptfiles.ASModule, findSymbol 
             let insideType = typedb.GetTypeByName(findSymbol.container_type);
             if (!insideType)
                 return null;
-            
+
             let dbSymbols = insideType.findSymbols(findSymbol.symbol_name);
             for (let sym of dbSymbols)
             {
@@ -197,7 +197,7 @@ export function GetSymbolDefinition(asmodule : scriptfiles.ASModule, findSymbol 
             let namespace = typedb.LookupNamespace(null, findSymbol.container_type);
             if (!namespace)
                 return null;
-            
+
             let dbSymbols = namespace.findSymbols(findSymbol.symbol_name);
             for (let sym of dbSymbols)
             {
@@ -222,7 +222,7 @@ export function GetSymbolDefinition(asmodule : scriptfiles.ASModule, findSymbol 
             let insideType = typedb.GetTypeByName(findSymbol.container_type);
             if (!insideType)
                 return null;
-            
+
             let accessName = findSymbol.symbol_name;
             if (accessName.startsWith("Get") || accessName.startsWith("Set"))
                 accessName = accessName.substring(3);
@@ -255,7 +255,7 @@ export function GetSymbolDefinition(asmodule : scriptfiles.ASModule, findSymbol 
             let namespace = typedb.LookupNamespace(null, findSymbol.container_type);
             if (!namespace)
                 return null;
-            
+
             let accessName = findSymbol.symbol_name;
             if (accessName.startsWith("Get") || accessName.startsWith("Set"))
                 accessName = accessName.substring(3);
@@ -392,7 +392,7 @@ export function GetHover(asmodule : scriptfiles.ASModule, position : Position) :
             let insideType = typedb.GetTypeByName(findSymbol.container_type);
             if (!insideType)
                 return null;
-            
+
             let symbols = insideType.findSymbols(findSymbol.symbol_name);
             let methods = [];
 
@@ -414,7 +414,7 @@ export function GetHover(asmodule : scriptfiles.ASModule, position : Position) :
             let namespace = typedb.LookupNamespace(null, findSymbol.container_type);
             if (!namespace)
                 return null;
-            
+
             let symbols = namespace.findSymbols(findSymbol.symbol_name);
             let methods = [];
 
@@ -436,7 +436,7 @@ export function GetHover(asmodule : scriptfiles.ASModule, position : Position) :
             let insideType = typedb.GetTypeByName(findSymbol.container_type);
             if (!insideType)
                 return null;
-            
+
             let sym = insideType.findFirstSymbol(findSymbol.symbol_name, typedb.DBAllowSymbol.Properties);
             if (sym instanceof typedb.DBProperty)
             {
@@ -449,7 +449,7 @@ export function GetHover(asmodule : scriptfiles.ASModule, position : Position) :
             let namespace = typedb.LookupNamespace(null, findSymbol.container_type);
             if (!namespace)
                 return null;
-            
+
             let sym = namespace.findFirstSymbol(findSymbol.symbol_name, typedb.DBAllowSymbol.Properties);
             if (sym instanceof typedb.DBProperty)
             {
@@ -462,7 +462,7 @@ export function GetHover(asmodule : scriptfiles.ASModule, position : Position) :
             let insideType = typedb.GetTypeByName(findSymbol.container_type);
             if (!insideType)
                 return null;
-            
+
             let accessName = findSymbol.symbol_name;
             if (accessName.startsWith("Get") || accessName.startsWith("Set"))
                 accessName = accessName.substring(3);
@@ -496,7 +496,7 @@ export function GetHover(asmodule : scriptfiles.ASModule, position : Position) :
             let namespace = typedb.LookupNamespace(null, findSymbol.container_type);
             if (!namespace)
                 return null;
-            
+
             let accessName = findSymbol.symbol_name;
             if (accessName.startsWith("Get") || accessName.startsWith("Set"))
                 accessName = accessName.substring(3);

--- a/language-server/tsconfig.json
+++ b/language-server/tsconfig.json
@@ -1,15 +1,15 @@
 {
-	"compilerOptions": {
-		"target": "es2020",
-		"lib": ["ES2020"],
-		"module": "commonjs",
-		"moduleResolution": "node",
-		"sourceMap": true,
-		"strict": true,
-		"outDir": "out",
-		"rootDir": "src",
-		"strictNullChecks": false,
-	},
-	"include": ["src"],
-	"exclude": ["node_modules", ".vscode-test"]
+    "compilerOptions": {
+        "target": "es2020",
+        "lib": ["ES2020"],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "strict": true,
+        "outDir": "out",
+        "rootDir": "src",
+        "strictNullChecks": false,
+    },
+    "include": ["src"],
+    "exclude": ["node_modules", ".vscode-test"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "unreal-angelscript",
-    "version": "1.2.3",
+    "version": "1.4.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "unreal-angelscript",
-            "version": "1.2.3",
+            "version": "1.4.4",
             "hasInstallScript": true,
             "dependencies": {
                 "@types/glob": "^7.1.3",
@@ -1320,6 +1320,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+            "dev": true,
             "engines": {
                 "node": ">=0.8.19"
             }
@@ -1401,7 +1402,8 @@
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
@@ -6203,6 +6205,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
             "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "dev": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -6240,6 +6243,7 @@
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -6433,7 +6437,8 @@
         "node_modules/text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
+            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+            "dev": true
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
@@ -6575,6 +6580,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -7687,7 +7693,8 @@
         "imurmurhash": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="
+            "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+            "dev": true
         },
         "inflight": {
             "version": "1.0.6",
@@ -7748,7 +7755,8 @@
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true
         },
         "js-tokens": {
             "version": "4.0.0",
@@ -11276,6 +11284,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
             "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "dev": true,
             "requires": {
                 "glob": "^7.1.3"
             }
@@ -11292,7 +11301,8 @@
         "safe-buffer": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true
         },
         "safer-buffer": {
             "version": "2.1.2",
@@ -11431,7 +11441,8 @@
         "text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
+            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+            "dev": true
         },
         "to-regex-range": {
             "version": "5.0.1",
@@ -11539,6 +11550,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
             }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,21 @@
 {
-	"compilerOptions": {
-		"module": "commonjs",
-		"target": "es2020",
-		"lib": ["ES2020"],
-		"outDir": "out",
-		"rootDir": "src",
-		"sourceMap": true
-	},
-	"include": [
-		"src"
-	],
-	"exclude": [
-		"node_modules",
-		".vscode-test"
-	],
-	"references": [
-		{ "path": "./extension" },
-		{ "path": "./language-server" }
-	]
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es2020",
+        "lib": ["ES2020"],
+        "outDir": "out",
+        "rootDir": "src",
+        "sourceMap": true
+    },
+    "include": [
+        "src"
+    ],
+    "exclude": [
+        "node_modules",
+        ".vscode-test"
+    ],
+    "references": [
+        { "path": "./extension" },
+        { "path": "./language-server" }
+    ]
 }


### PR DESCRIPTION
This is an optional PR that standardizes the whitespace in the repo.
- Converts tabs to 4 spaces (given the existing setting in `.vscode/settings.json`)
- Adds a setting to automatically trim trailing whitespace on save
- Trims existing trailing whitespace
- I saw some misaligned code in `language-server/src/server.ts` was aligned properly

Feel free to reject this one. This can cause quite a bit of merge conflicts, but it seems like this repo isn't active right now so it may be a good time to merge it. This was only 10 minutes of work so no hard feelings if you don't want to take it.