### PR TITLE
Remove `git.enabled` setting to defer to a user's setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,6 @@
     },
     "typescript.tsdk": "./node_modules/typescript/lib",
     "typescript.tsc.autoDetect": "off",
-    "git.enabled": false,
     "git.ignoreLimitWarning": true,
 
     "editor.insertSpaces": true,


### PR DESCRIPTION
This PR removes the repo's default `git.enabled: false` setting for VSCode. It was originally disabled due to this explanation by @GGLucas:

> Ah, just legacy reasons. The vscode git extension used to have some bugs and performance issues with unreal repos many years ago, so it ended up part of our default workspace settings until recently.

Removing the line allows the repo to defer to a user's default setting while enabling other users to use git in VSCode for this repo.