### PR TITLE
added fguid to whitelisted inline structs

### DIFF
--- a/language-server/src/inline_values.ts
+++ b/language-server/src/inline_values.ts
@@ -70,7 +70,7 @@ class InlineValueContext
 let WhitelistedInlineStructs = new Set<string>([
     "FVector", "FVector2D", "FVector4", "FIntVector",
     "FRotator", "FName", "FString", "FColor", "FLinearColor",
-    "FText",
+    "FText", "FGuid",
 ]);
 
 function CanTypeHaveInlineValue(scope : scriptfiles.ASScope, typename : string) : boolean


### PR DESCRIPTION
Allow showing inline value for `FGuid` type.

Relates to https://github.com/Hazelight/UnrealEngine-Angelscript/pull/357