### PR TITLE
Fix issue with variables being stored with a $ suffix for their key

### DIFF
--- a/extension/src/debug.ts
+++ b/extension/src/debug.ts
@@ -608,7 +608,7 @@ export class ASDebugSession extends LoggingDebugSession
             // Keep the full path in the name for our debug variables
             debugVariable.name = evalName.replace(/^[0-9]+:%.*%./g, "");
 
-            this.variableStore.set(evalName, debugVariable);
+            this.variableStore.set(this.combineExpression(id, variable.evaluateName), debugVariable);
             variables.push(variable);
         }
 


### PR DESCRIPTION
This was ausing some data breakpoints to not be valid since the underlying variable was not found in the map.