### PR TITLE
feat(GeneratedCode): add project settings for generated code

### DIFF
--- a/language-server/src/generated_code.ts
+++ b/language-server/src/generated_code.ts
@@ -2,6 +2,69 @@ import { assert } from 'console';
 import * as scriptfiles from './as_parser';
 import * as typedb from './database';
 
+interface ProjectCodeGenerationSettings
+{
+    enable : boolean,
+    generators : Generator[],
+}
+
+interface Generator
+{
+    derivedFrom : string,
+    staticFunctions : GeneratedStaticFunction[],
+    memberFunctions : GeneratedMemberFunction[],
+    staticAccessors : GeneratedStaticAccessor[],
+    memberAccessors : GeneratedMemberAccessor[],
+}
+
+interface GeneratedStaticFunction
+{
+    name : string,
+    returnType : string,
+    args : [GeneratorArgumentType],
+}
+
+interface GeneratedMemberFunction
+{
+    returnType : string,
+    name : string,
+    args : [GeneratorArgumentType],
+    const : boolean,
+}
+
+interface GeneratedStaticAccessor
+{
+    derivedFrom ?: string,
+    name : string,
+    returnType : string,
+    args : [GeneratorArgumentType],
+}
+
+interface GeneratedMemberAccessor
+{
+    derivedFrom ?: string,
+    returnType : string,
+    name : string,
+    args : [GeneratorArgumentType],
+    const : boolean,
+}
+
+interface GeneratorArgumentType
+{
+    type : string,
+    name : string,
+}
+
+let ProjectCodeGenerationSettings : ProjectCodeGenerationSettings = {
+    enable : false,
+    generators : [],
+};
+
+export function GetProjectCodeGenerationSettings() : ProjectCodeGenerationSettings
+{
+    return ProjectCodeGenerationSettings;
+}
+
 export function ProcessScriptTypeGeneratedCode(dbtype : typedb.DBType, asmodule : scriptfiles.ASModule)
 {
     // Code that all delegate structs have
@@ -37,6 +100,18 @@ export function ProcessScriptTypeGeneratedCode(dbtype : typedb.DBType, asmodule 
         // Hazelight-specific generated code only if it's configured on
         if (scriptfiles.GetScriptSettings().useAngelscriptHaze)
             AddHazeGeneratedCode(asmodule, dbtype, nsType);
+
+        // Project-specific generated code only if it's configured on
+        if (ProjectCodeGenerationSettings.enable)
+        {
+            for (let generator of ProjectCodeGenerationSettings.generators)
+            {
+                if (dbtype.inheritsFrom(generator.derivedFrom))
+                {
+                    ApplyProjectGeneratedCode(asmodule, dbtype, nsType, generator);
+                }
+            }
+        }
 
         // Merge namespace into the type database
         asmodule.namespaces.push(nsType);
@@ -443,4 +518,72 @@ function AddGeneratedCodeForUHazeEffectEventHandler(asmodule : scriptfiles.ASMod
             dbfunc.auxiliarySymbols = [{symbol_name: method.name, container_type: nsType.getQualifiedNamespace()}];
         }
     });
+}
+
+function ApplyProjectGeneratedCode(asmodule : scriptfiles.ASModule, dbtype : typedb.DBType, nsType : typedb.DBNamespace, generator : Generator) {
+    let Replace = (value : string, replacements : [string, string][]) => {
+        for (let [token, replacement] of replacements) {
+            value = value.replace(new RegExp(`\{${token}\}`, 'g'), replacement);
+        }
+        return value;
+    };
+
+    // Apply non-accessors
+    {
+        let tokens : [string, string][] = [['class', dbtype.name]];
+        for (let func of generator.staticFunctions)
+        {
+            let method = AddGlobalFunction(asmodule, dbtype, nsType, Replace(func.name, tokens));
+            method.returnType = Replace(func.returnType, tokens);
+            method.args = func.args.map((arg) => {
+                return new typedb.DBArg().init(Replace(arg.type, tokens), Replace(arg.name, tokens));
+            });
+        }
+        for (let func of generator.memberFunctions)
+        {
+            let method = AddMethod(dbtype, Replace(func.name, tokens));
+            method.returnType = Replace(func.returnType, tokens);
+            method.args = func.args.map((arg) => {
+                return new typedb.DBArg().init(Replace(arg.type, tokens), Replace(arg.name, tokens));
+            });
+        }
+    }
+
+    // Apply accessors
+    dbtype.forEachSymbol(function (sym : typedb.DBSymbol)
+    {
+        if (!(sym instanceof typedb.DBProperty))
+            return;
+        let prop = sym;
+        if (!prop.declaredModule)
+            return;
+        let propType = typedb.LookupType(prop.namespace, prop.typename);
+        if (!propType)
+            return;
+        let tokens : [string, string][] = [
+            ['class', dbtype.name],
+            ['propType', propType.name],
+            ['propName', prop.name]
+        ];
+        for (let func of generator.staticAccessors)
+        {
+            if (func.derivedFrom !== undefined && !propType.inheritsFrom(func.derivedFrom))
+                continue;
+            let method = AddGlobalFunction(asmodule, dbtype, nsType, Replace(func.name, tokens));
+            method.returnType = Replace(func.returnType, tokens);
+            method.args = func.args.map((arg) => {
+                return new typedb.DBArg().init(Replace(arg.type, tokens), Replace(arg.name, tokens));
+            });
+        }
+        for (let func of generator.memberAccessors)
+        {
+            if (func.derivedFrom !== undefined && !propType.inheritsFrom(func.derivedFrom))
+                continue;
+            let method = AddMethod(dbtype, Replace(func.name, tokens));
+            method.returnType = Replace(func.returnType, tokens);
+            method.args = func.args.map((arg) => {
+                return new typedb.DBArg().init(Replace(arg.type, tokens), Replace(arg.name, tokens));
+            });
+        }
+    }, false);
 }

--- a/language-server/src/server.ts
+++ b/language-server/src/server.ts
@@ -38,6 +38,7 @@ import * as scriptsymbols from './symbols';
 import * as scriptdiagnostics from './ls_diagnostics';
 import * as scriptlenses from './code_lenses';
 import * as scriptactions from './code_actions';
+import * as generatedcode from './generated_code';
 import * as assets from './assets';
 import * as inlayhints from './inlay_hints';
 import * as inlinevalues from './inline_values';
@@ -1143,6 +1144,10 @@ connection.onDidChangeConfiguration(function (change : DidChangeConfigurationPar
 
     let codeLensSettings = scriptlenses.GetCodeLensSettings();
     codeLensSettings.showCreateBlueprintClasses = settings.codeLenses.showCreateBlueprintClasses;
+
+    let projectCodeGenerationSettings = generatedcode.GetProjectCodeGenerationSettings();
+    projectCodeGenerationSettings.enable = settings.projectCodeGeneration.enable;
+    projectCodeGenerationSettings.generators = settings.projectCodeGeneration.generators;
 });
 
 function TryResolveInlayHints(asmodule : scriptfiles.ASModule, range : Range) : Array<InlayHint> | null

--- a/package.json
+++ b/package.json
@@ -127,12 +127,18 @@
                 },
                 "UnrealAngelscript.scriptIgnorePatterns": {
                     "type": "array",
-                    "default": ["**/Saved/**", "**/.plastic/**"],
+                    "default": [
+                        "**/Saved/**",
+                        "**/.plastic/**"
+                    ],
                     "description": "Glob patterns to ignore when searching for script files to parse."
                 },
                 "UnrealAngelscript.codeLenses.showCreateBlueprintClasses": {
                     "type": "array",
-                    "default": ["AActor", "UUserWidget"],
+                    "default": [
+                        "AActor",
+                        "UUserWidget"
+                    ],
                     "description": "Script classes inheriting from the specified classes will have a 'Create Blueprint' prompt above them if they don't already have a blueprint implementation."
                 },
                 "UnrealAngelscript.dataBreakpoints.cppBreakpoints.enable": {
@@ -149,6 +155,232 @@
                     "type": "number",
                     "default": -1,
                     "description": "How many times a AS Data Breakpoint should trigger (silently) before activating and disabling, -1 means it will never disable automatically."
+                },
+                "UnrealAngelscript.projectCodeGeneration.enable": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Should project code generation be enabled? If not, only built-in code generation will be applied."
+                },
+                "UnrealAngelscript.projectCodeGeneration.generators": {
+                    "type": "array",
+                    "description": "What generators to apply during analysis.",
+                    "items": {
+                        "type": "object",
+                        "description": "A code generator to apply to a given class/struct.",
+                        "properties": {
+                            "derivedFrom": {
+                                "type": "string",
+                                "default": "UObject",
+                                "description": "The class this generator will apply to."
+                            },
+                            "staticFunctions": {
+                                "type": "array",
+                                "default": [],
+                                "description": "List of static functions to generate for the target class.",
+                                "required": [
+                                    "returnType",
+                                    "name"
+                                ],
+                                "items": {
+                                    "properties": {
+                                        "returnType": {
+                                            "type": "string",
+                                            "default": "UObject",
+                                            "description": "The type name of the class/struct to be returned. Supports patterns such as `{class}`."
+                                        },
+                                        "name": {
+                                            "type": "string",
+                                            "default": "MyStaticFunc",
+                                            "description": "Name of this function. Supports patterns such as `{class}`."
+                                        },
+                                        "args": {
+                                            "type": "array",
+                                            "default": [],
+                                            "description": "List of argument types for this function.",
+                                            "items": {
+                                                "type": "object",
+                                                "required": [
+                                                    "type",
+                                                    "name"
+                                                ],
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "default": "UObject",
+                                                        "description": "The type name of the class/struct to be used. Supports patterns such as `{class}`."
+                                                    },
+                                                    "name": {
+                                                        "type": "string",
+                                                        "default": "UObject",
+                                                        "description": "The name of the argument. Supports patterns such as `{class}`."
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "memberFunctions": {
+                                "type": "array",
+                                "default": [],
+                                "description": "List of member functions to generate for the target class.",
+                                "items": {
+                                    "required": [
+                                        "returnType",
+                                        "name"
+                                    ],
+                                    "properties": {
+                                        "returnType": {
+                                            "type": "string",
+                                            "default": "UObject",
+                                            "description": "The type name of the class/struct to be returned. Supports patterns such as `{class}`."
+                                        },
+                                        "name": {
+                                            "type": "string",
+                                            "default": "MyMemberFunc",
+                                            "description": "Name of this function. Supports patterns such as `{class}`."
+                                        },
+                                        "args": {
+                                            "type": "array",
+                                            "description": "List of argument types for this function.",
+                                            "default": [],
+                                            "items": {
+                                                "type": "object",
+                                                "required": [
+                                                    "type",
+                                                    "name"
+                                                ],
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "default": "UObject",
+                                                        "description": "The type name of the class/struct to be used. Supports patterns such as `{class}`."
+                                                    },
+                                                    "name": {
+                                                        "type": "string",
+                                                        "default": "UObject",
+                                                        "description": "The name of the argument. Supports patterns such as `{class}`."
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "const": {
+                                            "type": "boolean",
+                                            "default": false,
+                                            "description": "Whether or not this function is const qualified."
+                                        }
+                                    }
+                                }
+                            },
+                            "staticAccessors": {
+                                "type": "array",
+                                "default": [],
+                                "description": "List of static accessors to generate for the target class.",
+                                "required": [
+                                    "returnType",
+                                    "name"
+                                ],
+                                "items": {
+                                    "properties": {
+                                        "derivedFrom": {
+                                            "type": "string",
+                                            "description": "The property type this generator will apply to."
+                                        },
+                                        "returnType": {
+                                            "type": "string",
+                                            "default": "UObject",
+                                            "description": "The type name of the class/struct to be returned. Supports patterns such as `{class}, {propType}, {propName}`."
+                                        },
+                                        "name": {
+                                            "type": "string",
+                                            "default": "MyStaticFunc",
+                                            "description": "Name of this function. Supports patterns such as `{class}, {propType}, {propName}`."
+                                        },
+                                        "args": {
+                                            "type": "array",
+                                            "default": [],
+                                            "description": "List of argument types for this function.",
+                                            "items": {
+                                                "type": "object",
+                                                "required": [
+                                                    "type",
+                                                    "name"
+                                                ],
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "default": "UObject",
+                                                        "description": "The type name of the class/struct to be used. Supports patterns such as `{class}, {propType}, {propName}`."
+                                                    },
+                                                    "name": {
+                                                        "type": "string",
+                                                        "default": "UObject",
+                                                        "description": "The name of the argument. Supports patterns such as `{class}, {propType}, {propName}`."
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "memberAccessors": {
+                                "type": "array",
+                                "default": [],
+                                "description": "List of member accessors to generate for the target class.",
+                                "items": {
+                                    "required": [
+                                        "returnType",
+                                        "name"
+                                    ],
+                                    "properties": {
+                                        "derivedFrom": {
+                                            "type": "string",
+                                            "description": "The property type this generator will apply to."
+                                        },
+                                        "returnType": {
+                                            "type": "string",
+                                            "default": "UObject",
+                                            "description": "The type name of the class/struct to be returned. Supports patterns such as `{class}, {propType}, {propName}`."
+                                        },
+                                        "name": {
+                                            "type": "string",
+                                            "default": "MyMemberFunc",
+                                            "description": "Name of this function. Supports patterns such as `{class}, {propType}, {propName}`."
+                                        },
+                                        "args": {
+                                            "type": "array",
+                                            "description": "List of argument types for this function.",
+                                            "default": [],
+                                            "items": {
+                                                "type": "object",
+                                                "required": [
+                                                    "type",
+                                                    "name"
+                                                ],
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "default": "UObject",
+                                                        "description": "The type name of the class/struct to be used. Supports patterns such as `{class}, {propType}, {propName}`."
+                                                    },
+                                                    "name": {
+                                                        "type": "string",
+                                                        "default": "UObject",
+                                                        "description": "The name of the argument. Supports patterns such as `{class}, {propType}, {propName}`."
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "const": {
+                                            "type": "boolean",
+                                            "default": false,
+                                            "description": "Whether or not this function is const qualified."
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },


### PR DESCRIPTION
This adds project settings for adding bindings for generated code that may exist in one's project. Thus making it much easier to add custom pre-processors to a project. To start with, it supports generating both `static`/`member` methods. Additionally allows you to specify "accessor" like methods, that may be declared for members of a given type.

Here's an example configuration:
```json
"UnrealAngelscript.projectCodeGeneration.enable": true,
"UnrealAngelscript.projectCodeGeneration.generators": [
    {
        "derivedFrom": "UAttributeSet",
        "staticFunctions": [
            {
                "returnType": "const {class}&",
                "name": "MyStaticFunc",
                "args": [
                    {
                        "type": "const FQuat&",
                        "name": "Test"
                    }
                ]
            }
        ],
        "memberFunctions": [
            {
                "returnType": "UObject",
                "name": "MyMemberFunc",
                "args": [
                    {
                        "type": "UObject",
                        "name": "Test"
                    }
                ]
            }
        ],
        "staticAccessors": [
            {
                "derivedFrom": "FGameplayAttributeData",
                "returnType": "const {propType}&",
                "name": "MyStaticFunc{propName}",
                "args": [
                    {
                        "type": "const FQuat&",
                        "name": "Test"
                    }
                ]
            }
        ],
        "memberAccessors": [
            {
                "returnType": "UObject",
                "name": "MyMemberFunc{propName}",
                "args": [
                    {
                        "type": "UObject",
                        "name": "Test"
                    }
                ]
            }
        ]
    }
],
```