### PR TITLE
Fix: Remove extra comma in mixin function signature

### DIFF
--- a/language-server/src/database.ts
+++ b/language-server/src/database.ts
@@ -444,7 +444,7 @@ export class DBMethod implements DBSymbol
                 let argDecl = this.args[i].format();
                 if (determineType && this.determinesOutputTypeArgumentIndex == i)
                     argDecl = this.args[i].format(this.applyDeterminesOutputType(this.args[i].typename, determineType).name);
-                if (i > 0 || (skipFirstArg && i > 1))
+                if (i > 1 || (!skipFirstArg && i > 0))
                     decl += ", ";
                 decl += argDecl;
             }


### PR DESCRIPTION
There is a small mistake in the condition for adding commas in function signature parameter list (the commas are always added), resulting in an extra comma in the mixin function signature. This PR fixes this issue.