### PR TITLE
Fix: Incorrect ternary expr type when left & right have same type

### DIFF
--- a/language-server/src/as_parser.ts
+++ b/language-server/src/as_parser.ts
@@ -3081,7 +3081,9 @@ export function ResolveTypeFromExpression(scope : ASScope, node : any) : typedb.
             {
                 if (right_type)
                 {
-                    if (left_type != right_type && !left_type.isValueType() && !right_type.isValueType())
+                    if (left_type === right_type)
+                        return left_type;
+                    if (!left_type.isValueType() && !right_type.isValueType())
                     {
                         // Find the common baseclass
                         let target_type = left_type;


### PR DESCRIPTION
The `ResolveTypeFromExpression` returns `null` for `TernaryOperation` when left type and right type are the same. This PR fixes this issue.