### PR TITLE
Fix: Template base type highlighting

### DIFF
--- a/language-server/src/semantic_highlighting.ts
+++ b/language-server/src/semantic_highlighting.ts
@@ -143,7 +143,7 @@ function BuildSymbols(asmodule : scriptfiles.ASModule, builder : SemanticTokensB
                 type = SemanticTypes.unknown_error;
             break;
             case scriptfiles.ASSymbolType.TemplateBaseType:
-                type = SemanticTypes.templae_base_type;
+                type = SemanticTypes.template_base_type;
             break;
             case scriptfiles.ASSymbolType.Parameter:
                 type = SemanticTypes.parameter;


### PR DESCRIPTION
There is a typo in **language-server/src/semantic_highlighting.ts** that breaks the highlighting of the template base type (`templae_base_type` -> `template_base_type`). This PR fixes this issue.