### PR TITLE
Add option to include completions from all workspaces

### DIFF
--- a/language-server/src/parsed_completion.ts
+++ b/language-server/src/parsed_completion.ts
@@ -26,11 +26,13 @@ export interface CompletionSettings
 {
     mathCompletionShortcuts : boolean,
     correctFloatLiteralsWhenExpectingDoublePrecision: boolean,
+    addCompletionFromAllNamespaces: boolean,
 };
 
 let CompletionSettings : CompletionSettings = {
     mathCompletionShortcuts: true,
     correctFloatLiteralsWhenExpectingDoublePrecision: false,
+    addCompletionFromAllNamespaces: false,
 };
 
 export function GetCompletionSettings() : CompletionSettings
@@ -295,6 +297,10 @@ export function Complete(asmodule: scriptfiles.ASModule, position: Position): Ar
     // Some completions force the entire completion list to be case-insensitivy for usability reasons
     if (context.forceCaseInsensitive)
         MakeCompletionsLowerCase(completions);
+
+    // pulls completions from all namespaces
+    if (CompletionSettings.addCompletionFromAllNamespaces)
+        AddCompletionsFromAllNamespaces(context, completions);
 
     return completions;
 }
@@ -4436,6 +4442,19 @@ export function AddMathShortcutCompletions(context : CompletionContext, completi
         if (completionNames.has(compl.label))
             continue;
         completions.push(compl);
+    }
+}
+
+function AddCompletionsFromAllNamespaces(context: CompletionContext, completions: Array<CompletionItem>) {
+    let namespaces = typedb.GetAllNamespaces().values();
+    let nameSpaceCompletions : Array<CompletionItem> = [];
+    for (let namespace of namespaces) {
+        AddCompletionsFromType(context, namespace, nameSpaceCompletions, false);
+        for(let completion of nameSpaceCompletions){
+            completion.label = namespace.name + "::" + completion.label;
+        }
+        completions.push(...nameSpaceCompletions);
+        nameSpaceCompletions = [];
     }
 }
 

--- a/language-server/src/server.ts
+++ b/language-server/src/server.ts
@@ -1128,6 +1128,7 @@ connection.onDidChangeConfiguration(function (change : DidChangeConfigurationPar
     let completionSettings = parsedcompletion.GetCompletionSettings();
     completionSettings.mathCompletionShortcuts = settings.mathCompletionShortcuts;
     completionSettings.correctFloatLiteralsWhenExpectingDoublePrecision = settings.correctFloatLiteralsWhenExpectingDoublePrecision;
+    completionSettings.addCompletionFromAllNamespaces = settings.addCompletionFromAllNamespaces;
 
     let inlayHintSettings = inlayhints.GetInlayHintSettings();
     inlayHintSettings.inlayHintsEnabled = settings.inlayHints.inlayHintsEnabled;

--- a/package.json
+++ b/package.json
@@ -50,6 +50,11 @@
                     "default": false,
                     "markdownDescription": "When a float literal is typed (eg `1.f`) in a context where double-precision is expected, automatically correct it (eg to `1.0`)"
                 },
+                "UnrealAngelscript.addCompletionFromAllNamespaces": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Add completions from all workspaces, not just the current one."
+                },
                 "UnrealAngelscript.inlayHints.inlayHintsEnabled": {
                     "type": "boolean",
                     "default": true,


### PR DESCRIPTION
Adding an option in the extension settings to include completions from all workspaces. To make it easier for developers to go from BP to AngelScript.

Original code by GlimpseBeyond (see: AddCompletionsFromAllNamespaces on Discord Server)