### PR TITLE
Fix nested namespace resolution overwriting top-level namespaces

### DIFF
--- a/language-server/src/database.ts
+++ b/language-server/src/database.ts
@@ -2538,7 +2538,9 @@ export function AddTypesFromUnreal(input : any)
                     }
                 }
 
-                let ns = LookupNamespace(parentNamespace, identifier);
+                let ns = parentNamespace
+                    ? parentNamespace.findChildNamespace(identifier)
+                    : LookupNamespace(null, identifier);
                 if (!ns)
                 {
                     ns = DeclareNamespace(parentNamespace, identifier, decl);


### PR DESCRIPTION
When C++ bindings register nested namespaces, LookupNamespace walks up the parent chain and can resolve to an unrelated top-level namespace with the same leaf name, destroying its symbols. This change uses direct child lookup instead when the parent is known.

Default engine doesn't actually have any cases with native nested namespaces, so this problem never appeared - but we had some custom bindings that do this, and it resulted in losing autocomplete for normal stuff. 

Specific case we had was that a nested namespace **GameplayTags::Gameplay::** ended up overriding the top-level **Gameplay::**.