### PR TITLE
Allow language server to be used independently of vscode extension

### DIFF
--- a/language-server/esbuild.js
+++ b/language-server/esbuild.js
@@ -34,6 +34,9 @@ async function main() {
 		sourcemap: !production,
 		sourcesContent: false,
 		platform: 'node',
+		banner: {
+			js: '#!/usr/bin/env node',
+		},
 		outdir: 'dist',
 		external: ['vscode'],
 		logLevel: 'silent',

--- a/language-server/package-lock.json
+++ b/language-server/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "lsp-sample-server",
+    "name": "ue-angelscript-ls",
     "version": "1.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "lsp-sample-server",
+            "name": "ue-angelscript-ls",
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
@@ -16,6 +16,9 @@
                 "vscode-languageserver": "^8.1.0",
                 "vscode-languageserver-textdocument": "^1.0.8",
                 "vscode-uri": "^3.0.3"
+            },
+            "bin": {
+                "ue-angelscript-ls": "dist/server.js"
             },
             "devDependencies": {
                 "@types/vscode": "^1.65.0",

--- a/language-server/package.json
+++ b/language-server/package.json
@@ -1,15 +1,18 @@
 {
-    "name": "lsp-sample-server",
-    "description": "Example implementation of a language server in node.",
-    "version": "1.0.0",
-    "author": "Microsoft Corporation",
+    "name": "ue-angelscript-ls",
+    "description": "",
+    "version": "0.1.0",
+    "bin": {
+        "ue-angelscript-ls": "dist/server.js"
+    },
+    "author": "Hazelight",
     "license": "MIT",
     "engines": {
         "node": "*"
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/Microsoft/vscode-extension-samples"
+        "url": "https://github.com/Hazelight/vscode-unreal-angelscript"
     },
     "dependencies": {
         "@types/glob": "^7.1.3",
@@ -25,5 +28,8 @@
         "typescript": "^4.5.5",
         "vscode-test": "^1.3.0"
     },
-    "scripts": {}
+    "scripts": {
+        "build": "node esbuild.js",
+        "prepare": "npm run build"
+    }
 }

--- a/language-server/src/server.ts
+++ b/language-server/src/server.ts
@@ -21,7 +21,7 @@ import {
     TypeHierarchySupertypesParams, TypeHierarchySubtypesParams,
     WorkspaceSymbol, DocumentSymbol,
     InlayHint, InlayHintParams,
-    InlineValue, InlineValueParams,
+    InlineValue, InlineValueParams, WorkspaceFolder,
 } from 'vscode-languageserver/node';
 import { TextDocument, TextDocumentContentChangeEvent } from 'vscode-languageserver-textdocument';
 
@@ -53,8 +53,14 @@ import {
     buildDisconnect, buildOpenAssets, buildCreateBlueprint
 } from './unreal-buffers';
 
-// Create a connection for the server. The connection uses Node's IPC as a transport
-let connection: Connection = createConnection(new IPCMessageReader(process), new IPCMessageWriter(process));
+// Create a connection for the server.
+//
+// If we have a Node IPC send function available, use that, otherwise use stdio
+// to be used as a standalone lsp client.
+const ipcSendAvailble = typeof process.send === 'function';
+let connection: Connection = ipcSendAvailble
+    ? createConnection(new IPCMessageReader(process), new IPCMessageWriter(process))
+    : createConnection(process.stdin, process.stdout);
 
 // Create a connection to unreal
 let unreal : Socket;
@@ -289,6 +295,11 @@ connect_unreal();
 let shouldSendDiagnosticRelatedInformation: boolean = false;
 let RootUris : string[] = [];
 
+// These should all be optional extras, i.e. the server should still function normally if it's undefined.
+type InitializationOptions = {
+    additionalScriptRootFolders?: WorkspaceFolder[]
+} | undefined;
+
 // After the server has started the client sends an initialize request. The server receives
 // in the passed params the rootPath of the workspace plus the client capabilities.
 connection.onInitialize((_params): InitializeResult => {
@@ -306,6 +317,18 @@ connection.onInitialize((_params): InitializeResult => {
         }
     }
 
+    const initializationOptions = _params.initializationOptions as InitializationOptions;
+
+    const additionalFolders = initializationOptions?.additionalScriptRootFolders;
+    if (additionalFolders) {
+        for (let scriptRootPath of additionalFolders) {
+            let uri = decodeURIComponent(scriptRootPath.uri);
+            if (!RootUris.includes(uri)) {
+                Roots.push(URI.parse(scriptRootPath.uri).fsPath);
+                RootUris.push(uri);
+            }
+        }
+    }
 
     connection.console.log("Workspace roots: " + Roots);
 


### PR DESCRIPTION
This PR does a few small changes to allow the `language-server/` to be used outside of the VSCode plugin as a language server in other environments.

It makes two behavioral changes:
1. Checks whether Node's IPC `process.send` is defined, and if not, uses stdin/stdout as the connection channels
2. Adds `initializationOptions.additionalScriptRootFolders` to the LSP initialize request params as a way to configure additional root path(s) to `Script` folders (see https://github.com/Hazelight/vscode-unreal-angelscript/pull/63#issuecomment-4499638356)

It also makes a couple meta-changes:
1. Adds a `prepare` script which will get automatically run during the process of a local `npm install`, which calls esbuild.
2. Adds a "banner" (automatically gets placed at the beginning of the file) shebang so that the output file is seen as executable
4. Marks `dist/server.js` as a "binary" script in `package.json`, to be picked up by `npm install`
5. Changes the package name to `ue-angelscript-ls`, which is what the package ""binary"" script will be called when installed.