### PR TITLE
Add scriptRootFolders setting for non-Script workspace roots

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -35,6 +35,20 @@ export function activate(context: ExtensionContext) {
         debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
     }
 
+    // Resolve scriptRootFolders setting into additionalScriptRootFolders for the LS
+    let initOptions: { additionalScriptRootFolders: { uri: string, name: string }[] } | undefined = undefined;
+    let scriptRootFolders: string[] = vscode.workspace.getConfiguration("UnrealAngelscript").get("scriptRootFolders") || [];
+    if (scriptRootFolders.length > 0 && vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
+        let workspaceRoot = vscode.workspace.workspaceFolders[0].uri.fsPath;
+        let additionalFolders: { uri: string, name: string }[] = [];
+        for (let relPath of scriptRootFolders) {
+            let absPath = path.resolve(workspaceRoot, relPath);
+            let folderUri = vscode.Uri.file(absPath).toString();
+            additionalFolders.push({ uri: folderUri, name: path.basename(absPath) });
+        }
+        initOptions = { additionalScriptRootFolders: additionalFolders };
+    }
+
     // Options to control the language client
     let clientOptions: LanguageClientOptions = {
         // Register the server for plain text documents
@@ -42,7 +56,8 @@ export function activate(context: ExtensionContext) {
         synchronize: {
             fileEvents: workspace.createFileSystemWatcher('**/*.as'),
             configurationSection: "UnrealAngelscript",
-        }
+        },
+        initializationOptions: initOptions,
     }
 
     console.log("Activate angelscript extension");

--- a/package.json
+++ b/package.json
@@ -173,6 +173,14 @@
                     "default": true,
                     "description": "When debugging, show an inline value above the function declaration to display the this pointer and Owner of the object."
                 },
+                "UnrealAngelscript.scriptRootFolders": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "markdownDescription": "Paths to Script root folders, relative to the workspace root. When set, these folders are added as additional script roots for the language server, allowing the workspace root to be a parent directory (e.g. a monorepo root) rather than the Script folder itself. Example: `[\"Projects/MyGame/Script\"]`"
+                },
                 "UnrealAngelscript.scriptIgnorePatterns": {
                     "type": "array",
                     "default": [


### PR DESCRIPTION
When the VS Code workspace root is a parent directory rather than the Script/ folder itself, the language server cannot compute correct module names, breaking intellisense, go-to-definition, and error diagnostics.

(Eg: We want to support Angelscript language server to work when we open the Unreal project root, containing our C++, engine and AS scripts in child folders, sometimes 2 levels deep)

This PR adds a UnrealAngelscript.scriptRootFolders setting that accepts workspace-relative paths to Script root folders. The extension resolves them to absolute URIs and passes them to the language server via the additionalScriptRootFolders initialization option (added in PR #63). No server-side changes required.